### PR TITLE
Bugfix port nan

### DIFF
--- a/lib/clients.js
+++ b/lib/clients.js
@@ -10,7 +10,7 @@ import { NodeClient, WalletClient } from 'bclient';
 
 export const {
   bpanelPort,
-  tls,
+  ssl,
   nodePath,
   walletPath
 } = options();
@@ -20,14 +20,14 @@ let walletClient = null;
 
 function bpanelClient() {
   if (!nodeClient)
-    nodeClient = new NodeClient({ port: bpanelPort, path: nodePath, tls })
+    nodeClient = new NodeClient({ port: bpanelPort, path: nodePath, ssl });
 
   return nodeClient;
 }
 
 function bwalletClient() {
   if (!walletClient)
-    walletClient = new WalletClient({ port: bpanelPort, path: walletPath, tls })
+    walletClient = new WalletClient({ port: bpanelPort, path: walletPath, ssl });
 
   return walletClient;
 }
@@ -36,20 +36,16 @@ function options() {
   // bpanel endpoints
   const nodePath = '/bcoin';
   const walletPath = '/bwallet';
-  // determine the port and tls usage
+  // determine the port and ssl usage
   const protocol = window.location.protocol;
   let port = window.location.port;
-  let tls = false;
+  let ssl = false;
   // use https and http ports when the window doesn't render them
-  if (protocol === 'https:' && port === '') {
-    port = '443';
-    tls = true;
-  } else if (protocol === 'http:' && port === '') {
-    port = '80';
-  }
+  if (port === '') protocol === 'https:' ? port = '443' : port = '80';
+  if (protocol === 'https:') ssl = true;
   return {
     bpanelPort: parseInt(port),
-    tls,
+    ssl,
     nodePath,
     walletPath
   }

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -8,28 +8,55 @@
 
 import { NodeClient, WalletClient } from 'bclient';
 
-export const nodePath = '/bcoin';
-export const walletPath = '/bwallet';
-export const bpanelPort = parseInt(window.location.port);
+export const {
+  bpanelPort,
+  tls,
+  nodePath,
+  walletPath
+} = options();
 
 let nodeClient = null;
 let walletClient = null;
 
 function bpanelClient() {
   if (!nodeClient)
-    nodeClient = new NodeClient({ port: bpanelPort, path: nodePath })
+    nodeClient = new NodeClient({ port: bpanelPort, path: nodePath, tls })
 
   return nodeClient;
 }
 
 function bwalletClient() {
   if (!walletClient)
-    walletClient = new WalletClient({ port: bpanelPort, path: walletPath })
+    walletClient = new WalletClient({ port: bpanelPort, path: walletPath, tls })
 
   return walletClient;
+}
+
+function options() {
+  // bpanel endpoints
+  const nodePath = '/bcoin';
+  const walletPath = '/bwallet';
+  // determine the port and tls usage
+  const protocol = window.location.protocol;
+  const port = window.location.port;
+  const tls = false;
+  // use https and http ports when the window doesn't render them
+  if (protocol === 'https:' && port === '') {
+    port = '443';
+    tls = true;
+  } else if (protocol === 'http:' && port === '') {
+    port = '80';
+  }
+  return {
+    bpanelPort: parseInt(port),
+    tls,
+    nodePath,
+    walletPath
+  }
 }
 
 export {
   bpanelClient,
   bwalletClient
 }
+

--- a/lib/clients.js
+++ b/lib/clients.js
@@ -38,8 +38,8 @@ function options() {
   const walletPath = '/bwallet';
   // determine the port and tls usage
   const protocol = window.location.protocol;
-  const port = window.location.port;
-  const tls = false;
+  let port = window.location.port;
+  let tls = false;
   // use https and http ports when the window doesn't render them
   if (protocol === 'https:' && port === '') {
     port = '443';


### PR DESCRIPTION
If the site is served on `80` or `443`, then `window.location.port` is `""` which was then passed into `parseInt` which resulted in `NaN`

This handles the case the case when `window.location.protocol` is `https:`, it enables `ssl` by passing a bool into the client constructors