### PR TITLE
feature: return input count and output count

### DIFF
--- a/lib/uxtx.js
+++ b/lib/uxtx.js
@@ -612,6 +612,8 @@ class UXTX extends TX {
       outputs: json.outputs,
       inputAmount,
       outputAmount,
+      inputCount: json.inputs.length,
+      outputCount: json.outputs.length,
       weight,
       date,
       amount,


### PR DESCRIPTION
This can easily be computed by the consumer, but this makes it much easier to integrate with the current `expandedatarow`