### PR TITLE
Block explorer client

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ A wrapper around `UXTX` to manage many transactions.
 
 import { TxManager, TxManagerOptions, UXTXOptions } from '@bpanel/bpanel-utils';
 
+// set bitcoin as the current chain
+UXTXOptions.chain = 'bitcoin';
+
 // use default tx parsing logic
 const txManager = TxManager.fromOptions(TxManagerOptions);
 

--- a/lib/blockExplorerClient.js
+++ b/lib/blockExplorerClient.js
@@ -133,7 +133,4 @@ class BlockExplorerClient {
 
 module.exports = {
   BlockExplorerClient,
-  CHAINS,
-  BLOCK_EXPLORERS,
-  EXPLORER_SUFFIXES,
 }

--- a/lib/blockExplorerClient.js
+++ b/lib/blockExplorerClient.js
@@ -2,8 +2,8 @@ const { networks } = require('bcoin');
 const assert = require('bsert');
 const url = require('url');
 
-// supported protocols
-const PROTOCOLS = ['bitcoin', 'bitcoincash'];
+// supported chains
+const CHAINS = ['bitcoin', 'bitcoincash'];
 
 // supported block explorers
 // can add more here
@@ -44,7 +44,7 @@ const EXPLORER_SUFFIXES = {
  *
  * currently supports:
  * networks: main,testnet
- * chain: bitcoin,bitcoincash
+ * network: bitcoin,bitcoincash
  *
  * rendering of tx hyperlinks
  *
@@ -58,11 +58,11 @@ class BlockExplorerClient {
    */
   constructor(options) {
     this._explorers = BLOCK_EXPLORERS;
-    this._protocols = PROTOCOLS;
+    this._chains = CHAINS;
     this._suffixes = EXPLORER_SUFFIXES;
     this._networks = networks.types;
-    this._protocol = null;
     this._chain = null;
+    this._network = null;
 
     if (options)
       this.fromOptions(options);
@@ -74,14 +74,14 @@ class BlockExplorerClient {
 
   fromOptions(options) {
     assert(typeof options === 'object', 'options must be an object');
-    assert(options.protocol, 'must pass a protocol');
-    assert(options.chain, 'must past a chain network, ie main or testnet');
+    assert(options.chain, 'must pass options.chain');
+    assert(options.network, 'must past options.network');
 
-    assert(this._protocols.includes(options.protocol), `${options.protocol} must be a valid protocol: ${this._protocols}`)
-    this._protocol = options.protocol;
-
-    assert(this._networks.includes(options.chain), `${options.chain} must be a valid chain: ${this._networks}`);
+    assert(this._chains.includes(options.chain), `${options.chain} must be a valid chain: ${this._chains}`)
     this._chain = options.chain;
+
+    assert(this._networks.includes(options.network), `${options.network} must be a valid network: ${this._networks}`);
+    this._network = options.network;
 
     return this;
   }
@@ -90,7 +90,7 @@ class BlockExplorerClient {
    * get compatible explorers
    */
   getExplorers() {
-    return this._explorers[this._protocol][this._chain];
+    return this._explorers[this._chain][this._network];
   }
 
   /**
@@ -133,7 +133,7 @@ class BlockExplorerClient {
 
 module.exports = {
   BlockExplorerClient,
-  PROTOCOLS,
+  CHAINS,
   BLOCK_EXPLORERS,
   EXPLORER_SUFFIXES,
 }

--- a/lib/blockExplorerClient.js
+++ b/lib/blockExplorerClient.js
@@ -2,8 +2,11 @@ const { networks } = require('bcoin');
 const assert = require('bsert');
 const url = require('url');
 
+// supported protocols
 const PROTOCOLS = ['bitcoin', 'bitcoincash'];
 
+// supported block explorers
+// can add more here
 const BLOCK_EXPLORERS = {
   bitcoin: {
     main: {
@@ -25,6 +28,8 @@ const BLOCK_EXPLORERS = {
   },
 };
 
+// the hyperlink suffixes for
+// different types of queries
 const EXPLORER_SUFFIXES = {
   blocktrail: {
     transaction: '/tx/',
@@ -34,9 +39,23 @@ const EXPLORER_SUFFIXES = {
   },
 };
 
-// networks: main,testnet
-// chain: bitcoin,bitcoincash
+/**
+ * block explorer client
+ *
+ * currently supports:
+ * networks: main,testnet
+ * chain: bitcoin,bitcoincash
+ *
+ * rendering of tx hyperlinks
+ *
+ */
 class BlockExplorerClient {
+  /**
+   * Create a block explorer client
+   * @constructor
+   * @param options
+   *
+   */
   constructor(options) {
     this._explorers = BLOCK_EXPLORERS;
     this._protocols = PROTOCOLS;
@@ -67,19 +86,39 @@ class BlockExplorerClient {
     return this;
   }
 
+  /**
+   * get compatible explorers
+   */
   getExplorers() {
     return this._explorers[this._protocol][this._chain];
   }
 
+  /**
+   * get suffixes for explorer hyperlinks
+   */
   getSuffixes() {
     return this._suffixes;
   }
 
+  /**
+   * string interpolate the hyperlink
+   * @param name
+   * @param url
+   * @param type
+   * @returns {String}
+   */
   toLink(name, url, type) {
     const suffixes = this.getSuffixes();
     return `${url}${suffixes[name][type]}`;
   }
 
+  /**
+   * render transaction specific
+   * hyperlinks for each supported
+   * block explorer
+   * @param txhash
+   * @returns {[]url.URL}
+   */
   getTransactionLinks(txhash) {
     const explorers = this.getExplorers();
     const links = [];

--- a/lib/blockExplorerClient.js
+++ b/lib/blockExplorerClient.js
@@ -1,0 +1,100 @@
+const { networks } = require('bcoin');
+const assert = require('bsert');
+const url = require('url');
+
+const PROTOCOLS = ['bitcoin', 'bitcoincash'];
+
+const BLOCK_EXPLORERS = {
+  bitcoin: {
+    main: {
+      'btc.com': 'https://btc.com', // /{txhash}
+      blocktrail: 'https://www.blocktrail.com/BTC',
+    },
+    testnet: {
+      blocktrail: 'https://www.blocktrail.com/tBTC', // /tx/{txhash}
+    }
+  },
+  bitcoincash: {
+    main: {
+      'btc.com': 'https://bch.btc.com',
+      blocktrail: 'https://www.blocktrail.com/BCC',
+    },
+    testnet: {
+      blocktrail: 'https://www.blocktrail.com/tBCC',
+    },
+  },
+};
+
+const EXPLORER_SUFFIXES = {
+  blocktrail: {
+    transaction: '/tx/',
+  },
+  'btc.com': {
+    transaction: '/',
+  },
+};
+
+// networks: main,testnet
+// chain: bitcoin,bitcoincash
+class BlockExplorerClient {
+  constructor(options) {
+    this._explorers = BLOCK_EXPLORERS;
+    this._protocols = PROTOCOLS;
+    this._suffixes = EXPLORER_SUFFIXES;
+    this._networks = networks.types;
+    this._protocol = null;
+    this._chain = null;
+
+    if (options)
+      this.fromOptions(options);
+  }
+
+  static fromOptions(options) {
+    return new this().fromOptions(options);
+  }
+
+  fromOptions(options) {
+    assert(typeof options === 'object', 'options must be an object');
+    assert(options.protocol, 'must pass a protocol');
+    assert(options.chain, 'must past a chain network, ie main or testnet');
+
+    assert(this._protocols.includes(options.protocol), `${options.protocol} must be a valid protocol: ${this._protocols}`)
+    this._protocol = options.protocol;
+
+    assert(this._networks.includes(options.chain), `${options.chain} must be a valid chain: ${this._networks}`);
+    this._chain = options.chain;
+
+    return this;
+  }
+
+  getExplorers() {
+    return this._explorers[this._protocol][this._chain];
+  }
+
+  getSuffixes() {
+    return this._suffixes;
+  }
+
+  toLink(name, url, type) {
+    const suffixes = this.getSuffixes();
+    return `${url}${suffixes[name][type]}`;
+  }
+
+  getTransactionLinks(txhash) {
+    const explorers = this.getExplorers();
+    const links = [];
+    for (let [key, val] of Object.entries(explorers)) {
+      const link = this.toLink(key, val, 'transaction');
+      const u = url.parse(`${link}${txhash}`);
+      links.push(u);
+    }
+    return links;
+  }
+}
+
+module.exports = {
+  BlockExplorerClient,
+  PROTOCOLS,
+  BLOCK_EXPLORERS,
+  EXPLORER_SUFFIXES,
+}

--- a/lib/uxtx.js
+++ b/lib/uxtx.js
@@ -592,6 +592,7 @@ class UXTX extends TX {
    *
    * TODO: consolidate output values to make most flexible
    * TODO: don't hardcode segwit and coinbase labels
+   * TODO: indicator of coin type, bitcoin or bitcoincash
    */
   toJSON() {
     const json = this.getJSON();
@@ -616,6 +617,7 @@ class UXTX extends TX {
 
     const inputAmount = this.getAmount('inputs');
     const outputAmount = this.getAmount('outputs');
+
 
     return {
       hash: json.hash,

--- a/lib/uxtx.js
+++ b/lib/uxtx.js
@@ -591,7 +591,6 @@ class UXTX extends TX {
    *
    * TODO: consolidate output values to make most flexible
    * TODO: don't hardcode segwit and coinbase labels
-   * TODO: indicator of coin type, bitcoin or bitcoincash
    */
   toJSON() {
     const json = this.getJSON();

--- a/lib/uxtx.js
+++ b/lib/uxtx.js
@@ -45,7 +45,7 @@ class UXTX extends TX {
     this._accounts = null;
     this._counterparty = null;
     this._recipients = null;
-    this._protocol = null;
+    this._chain = null;
 
     if (options)
       this.fromOptions(options);
@@ -60,7 +60,7 @@ class UXTX extends TX {
    * @param {Object} options.constants.DATE_FORMAT - moment.js date format string
    * @param {Object} options.labels - human readable labels
    * @param {String} options.wallet - wallet that the txs belong to
-   * @param {String} options.protocol - protocol transaction is valid on (bitcoin or bitcoincash)
+   * @param {String} options.chain - chain transaction is valid on (bitcoin or bitcoincash)
    */
   fromOptions(options) {
     // allow for bcoin.TX options
@@ -86,11 +86,11 @@ class UXTX extends TX {
       this._wallet = options.wallet;
     }
 
-    if (options.protocol) {
-      assert(typeof options.protocol === 'string');
-      // TODO: handshake support?
-      assert(options.protocol === 'bitcoin' || options.protocol === 'bitcoincash');
-      this._protocol = options.protocol;
+    if (options.chain) {
+      assert(typeof options.chain === 'string');
+      // TODO: handshake support
+      assert(options.chain === 'bitcoin' || options.chain === 'bitcoincash', 'must pass a supported chain');
+      this._chain = options.chain;
     }
 
     return this;
@@ -294,12 +294,11 @@ class UXTX extends TX {
   }
 
   /*
-   * Get coin type
-   * the protocol this
+   * Get chain type - bitcoin,bitcoincash
    * @returns {String}
    */
-  getProtocol() {
-    return this._protocol;
+  getChain() {
+    return this._chain;
   }
 
   /*
@@ -606,7 +605,7 @@ class UXTX extends TX {
 
     const wallet = this.getWallet();
     const amount = this.getKnownAmount('btc', true);
-    const protocol = this.getProtocol();
+    const chain = this.getChain();
 
     const account = this.getAccount();
     const uxtypeLabel = this.getLabels(uxtype);
@@ -647,7 +646,7 @@ class UXTX extends TX {
       accountLabel: account,
       segwitLabel: isSegwit ? 'Yes' : 'No',
       coinbaseLabel: isCoinbase ? 'Yes' : 'No',
-      protocol,
+      chain,
       uxtype: uxtypeLabel,
     };
   }
@@ -674,13 +673,13 @@ const constants = {
 
 // valid networks:
 // bitcoin, bitcoincash
-const protocol = null;
+const chain = null;
 
 // additional options for UXTX
 const UXTXOptions = {
   constants,
   labels,
-  protocol,
+  chain,
   json: null, // tx json
 };
 

--- a/test/explorer-client.js
+++ b/test/explorer-client.js
@@ -4,8 +4,6 @@ const fetch = require('node-fetch');
 
 import {
   BlockExplorerClient,
-  BLOCK_EXPLORERS,
-  EXPLORER_SUFFIXES,
 } from '../lib/blockExplorerClient.js';
 
 describe('Block Explorer Client', () => {

--- a/test/explorer-client.js
+++ b/test/explorer-client.js
@@ -12,8 +12,8 @@ describe('Block Explorer Client', () => {
   it('Should instantiate from options', () => {
 
     const client = BlockExplorerClient.fromOptions({
-      protocol: 'bitcoin',
-      chain: 'main',
+      chain: 'bitcoin',
+      network: 'main',
     });
 
     assert.ok(client);
@@ -21,18 +21,16 @@ describe('Block Explorer Client', () => {
 
   it('Should return transaction urls', () => {
 
-    const chain = 'main';
-    const protocol = 'bitcoin';
+    const network = 'main';
+    const chain = 'bitcoin';
     const txhash = 'foobar';
 
     const client = BlockExplorerClient.fromOptions({
-      protocol,
+      network,
       chain,
     });
 
     const links = client.getTransactionLinks(txhash);
-
-    const suffixes = client.getSuffixes();
 
     for (let link of links)
       assert.equal(link.href.includes(txhash), true, 'it should render with the tx hash');

--- a/test/explorer-client.js
+++ b/test/explorer-client.js
@@ -1,0 +1,41 @@
+import { assert } from 'chai';
+const url = require('url');
+const fetch = require('node-fetch');
+
+import {
+  BlockExplorerClient,
+  BLOCK_EXPLORERS,
+  EXPLORER_SUFFIXES,
+} from '../lib/blockExplorerClient.js';
+
+describe('Block Explorer Client', () => {
+  it('Should instantiate from options', () => {
+
+    const client = BlockExplorerClient.fromOptions({
+      protocol: 'bitcoin',
+      chain: 'main',
+    });
+
+    assert.ok(client);
+  });
+
+  it('Should return transaction urls', () => {
+
+    const chain = 'main';
+    const protocol = 'bitcoin';
+    const txhash = 'foobar';
+
+    const client = BlockExplorerClient.fromOptions({
+      protocol,
+      chain,
+    });
+
+    const links = client.getTransactionLinks(txhash);
+
+    const suffixes = client.getSuffixes();
+
+    for (let link of links)
+      assert.equal(link.href.includes(txhash), true, 'it should render with the tx hash');
+  });
+});
+


### PR DESCRIPTION
This is built on top of the other open pull request here: https://github.com/bpanel-org/bpanel-utils/pull/18

Adds a client that returns hyperlinks to block explorers based on the chain type and network type

Was working on another test that asserted http request 200/300s to the sites, that is a WIP still