### PR TITLE
expose getBlockInfo

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -114,6 +114,7 @@ export function isChainSupported(chain) {
 
 export default {
   calcProgress,
+  getBlockInfo,
   getBlock,
   getBlocksInRange,
   isChainSupported,


### PR DESCRIPTION
Need to use this to make an update in recent-blocks and realized it wasn't actually exposed