### PR TITLE
add currency class

### DIFF
--- a/lib/currency.js
+++ b/lib/currency.js
@@ -41,7 +41,7 @@ class Currency extends Amount {
    * Create an object for getting currency units and amounts
    * @constructor
    * @param {string} chain - one of supported chain types
-   * see { chain.CHAINS }
+   * see {@link module:chain.CHAINS}
    * @param {(String|Number)?} value
    * @param {String?} unit
    * @returns {Currency}

--- a/lib/currency.js
+++ b/lib/currency.js
@@ -27,6 +27,12 @@ export const CURRENCY_TYPES = {
   micro: 'micro',
   base: 'base',
 };
+
+export const CHAIN_EXP = {
+  bitcoin: 8,
+  bitcoincash: 8,
+  handshake: 6,
+}
 // bitcoincash units currently same as bitcoin
 CURRENCY_UNITS.bitcoincash = { ...CURRENCY_UNITS.bitcoin };
 
@@ -45,9 +51,10 @@ class Currency extends Amount {
     const options = new CurrencyOptions(chain);
     this.chain = options.chain;
     this.units = options.units;
+    this.exp = CHAIN_EXP[this.chain];
   }
 
-  /*
+  /**
    * Get actual unit string
    * @param {string} unit - one of supported unit types
    * returns {string}
@@ -74,9 +81,7 @@ class Currency extends Amount {
       case 'bits':
         return this.toBits(num);
       case types.milli:
-        // hsd's `toMilli` has a bug
-        // this is a temporary fix
-        return Amount.encode(this.value, 5, num);
+        return this.toMilli(num);
       case types.currency:
       case types.unit:
         return this.toCoins(num);
@@ -118,6 +123,63 @@ class Currency extends Amount {
 
   static from(chain, unit, value) {
     return new this(chain).from(unit, value);
+  }
+
+  /**
+   * The remaining methods overwrite methods
+   * from the Amount class this inherits from
+   * in order ot account for different unit exponents
+   * by chain
+   */
+
+  /**
+   * Inject properties from value.
+   * @private
+   * @param {Number|String} value
+   * @returns {Amount}
+   */
+
+  fromCoins(value) {
+    this.value = Amount.decode(value, this.exp);
+    return this;
+  }
+
+  /**
+   * Get currency string or value.
+   * @param {Boolean?} num
+   * @returns {String|Amount}
+   */
+
+  toCoins(num) {
+    return Amount.encode(this.value, this.exp, num);
+  }
+
+  /**
+   * Get milli unit string or value.
+   * encoded with exponent of 3 less than
+   * largest unit (i.e. a "coin")
+   * @param {Boolean?} num
+   * @returns {String|Amount}
+   */
+
+  toMilli(num) {
+    const milliExp = this.exp - 3;
+    return Amount.encode(this.value, milliExp, num);
+  }
+
+  /**
+   * Inject properties from milli unit of currency.
+   * encoded with exponent of 3 less than
+   * largest unit (i.e. a "coin")
+   * @private
+   * @param {Number|String} value
+   * @returns {Amount}
+   */
+
+  fromMilli(value) {
+    const milliExp = this.exp - 3;
+    this.value = Amount.decode(value, milliExp);
+    return this;
   }
 }
 

--- a/lib/currency.js
+++ b/lib/currency.js
@@ -1,0 +1,134 @@
+const { Amount, pkg: hsdPkg } = require('hsd');
+const assert = require('bsert');
+
+const { isChainSupported } = require('./chain');
+
+export const CURRENCY_UNITS = {
+  bitcoin: {
+    currency: 'bitcoin',
+    unit: 'btc',
+    milli: 'mbtc',
+    micro: 'bit',
+    base: 'satoshi',
+  },
+  handshake: {
+    currency: hsdPkg.currency,
+    unit: hsdPkg.unit,
+    milli: `m${hsdPkg.unit}`,
+    micro: `u${hsdPkg.unit}`,
+    base: hsdPkg.base,
+  },
+};
+
+export const CURRENCY_TYPES = {
+  currency: 'currency',
+  unit: 'unit',
+  milli: 'milli',
+  micro: 'micro',
+  base: 'base',
+};
+// bitcoincash units currently same as bitcoin
+CURRENCY_UNITS.bitcoincash = { ...CURRENCY_UNITS.bitcoin };
+
+class Currency extends Amount {
+  /**
+   * Create an object for getting currency units and amounts
+   * @constructor
+   * @param {string} chain - one of supported chain types
+   * see { chain.CHAINS }
+   * @param {(String|Number)?} value
+   * @param {String?} unit
+   * @returns {Currency}
+   */
+  constructor(chain, value, unit) {
+    super(value, unit);
+    const options = new CurrencyOptions(chain);
+    this.chain = options.chain;
+    this.units = options.units;
+  }
+
+  /*
+   * Get actual unit string
+   * @param {string} unit - one of supported unit types
+   * returns {string}
+   */
+  getUnit(unit) {
+    assert(CURRENCY_TYPES[unit], `${unit} not a supported unit type`);
+    return this.units[unit];
+  }
+
+  /**
+   * Get unit string or value.
+   * Overwrites hsd's Amount for more generalized API
+   * @param {String} unit
+   * @param {Boolean?} num
+   * @returns {String|Amount}
+   */
+
+  to(unit, num) {
+    const types = CURRENCY_TYPES;
+    switch (unit) {
+      case types.base:
+        return this.toBase(num);
+      case types.micro:
+      case 'bits':
+        return this.toBits(num);
+      case types.milli:
+        // hsd's `toMilli` has a bug
+        // this is a temporary fix
+        return Amount.encode(this.value, 5, num);
+      case types.currency:
+      case types.unit:
+        return this.toCoins(num);
+    }
+    throw new Error(`Unknown unit "${unit}".`);
+  }
+
+  /**
+   * Inject properties from unit.
+   * @private
+   * @param {String} unit
+   * @param {Number|String} value
+   * @returns {Amount}
+   */
+
+  from(unit, value) {
+    const types = CURRENCY_TYPES;
+    switch (unit) {
+      case types.base:
+        return this.fromBase(value);
+      case types.micro:
+      case 'bits':
+        return this.fromBits(value);
+      case types.milli:
+        return this.fromMilli(value);
+      case types.currency:
+      case types.unit:
+        return this.fromCoins(value);
+    }
+    throw new Error(`Unknown unit "${unit}".`);
+  }
+
+  /**
+   * Instantiate amount from unit.
+   * @param {String} unit
+   * @param {Number|String} value
+   * @returns {Amount}
+   */
+
+  static from(chain, unit, value) {
+    return new this(chain).from(unit, value);
+  }
+}
+
+class CurrencyOptions {
+  constructor(chain) {
+    assert(chain, 'must pass a chain to create Currency object');
+    assert(isChainSupported(chain), `${chain} is not a supported chain`);
+    this.chain = chain;
+    this.units = CURRENCY_UNITS[this.chain];
+    return this;
+  }
+}
+
+export default Currency;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,8 @@ export { getClient } from './clients';
 export { default as chain } from './chain';
 export { default as helpers } from './helpers';
 export { default as plugins } from './plugins';
+export { default as Currency } from './currency';
+export { CURRENCY_TYPES, CURRENCY_UNITS } from './currency';
 
 // TxManager handles many UXTXs
 export { TxManager, TxManagerOptions } from './txManager';

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ export { default as chain } from './chain';
 export { default as helpers } from './helpers';
 export { default as plugins } from './plugins';
 export { default as Currency } from './currency';
-export { CURRENCY_TYPES, CURRENCY_UNITS } from './currency';
+export { CURRENCY_TYPES, CURRENCY_UNITS, CHAIN_EXP } from './currency';
 
 // TxManager handles many UXTXs
 export { TxManager, TxManagerOptions } from './txManager';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1461,57 +1461,179 @@
       }
     },
     "bcoin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcoin/-/bcoin-1.0.2.tgz",
-      "integrity": "sha512-eG7j7giwjWHa6et1ZSTgqELRKOFRaQYWDdpA0AbQQO1Xw5K8nqIDPuXySwO18Y9S2Ik+VkvAqL6IlmfnYzA3mw==",
+      "version": "github:bcoin-org/bcoin#fe340265c87a969ca6c862dfdd238d9f2d5883be",
+      "from": "github:bcoin-org/bcoin",
       "dev": true,
       "requires": {
-        "bcfg": "~0.1.0",
-        "bclient": "~0.1.1",
-        "bcrypto": "~0.3.7",
-        "bdb": "~0.2.1",
-        "bdns": "~0.1.0",
-        "bevent": "~0.1.0",
-        "bfile": "~0.1.0",
-        "bfilter": "~0.2.0",
-        "bheep": "~0.1.0",
-        "binet": "~0.3.0",
-        "blgr": "~0.1.0",
-        "blru": "~0.1.0",
-        "blst": "~0.1.0",
-        "bmutex": "~0.1.0",
-        "bn.js": "~4.11.8",
-        "bsip": "~0.1.0",
-        "bsock": "~0.1.0",
-        "bsocks": "~0.2.0",
-        "bstring": "~0.1.0",
-        "btcp": "~0.1.0",
-        "bufio": "~0.2.0",
-        "bupnp": "~0.2.1",
-        "bval": "~0.1.0",
-        "bweb": "~0.1.1",
-        "mrmr": "~0.1.0",
-        "n64": "~0.2.0"
+        "bcfg": "~0.1.3",
+        "bclient": "~0.1.4",
+        "bcrypto": "~2.0.0",
+        "bdb": "~1.1.1",
+        "bdns": "~0.1.2",
+        "bevent": "~0.1.2",
+        "bfile": "~0.1.2",
+        "bfilter": "~1.0.1",
+        "bheep": "~0.1.2",
+        "binet": "~0.3.2",
+        "blgr": "~0.1.2",
+        "blru": "~0.1.3",
+        "blst": "~0.1.2",
+        "bmutex": "~0.1.3",
+        "bsert": "~0.0.4",
+        "bsip": "~0.1.2",
+        "bsock": "~0.1.3",
+        "bsocks": "~0.2.2",
+        "bstring": "~0.3.0",
+        "btcp": "~0.1.2",
+        "buffer-map": "~0.0.3",
+        "bufio": "~1.0.2",
+        "bupnp": "~0.2.3",
+        "bval": "~0.1.3",
+        "bweb": "~0.1.4",
+        "mrmr": "~0.1.2",
+        "n64": "~0.2.2"
       },
       "dependencies": {
+        "bcfg": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.3.tgz",
+          "integrity": "sha512-N/ZpKumfVYcAE5nYc0t4guvMGmtFaFn2QLUVZ0+0e1DBoRR7U6uh94pES7d2R7BKiYuVN1EI9bgOGmWGK4Kvig==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bclient": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/bclient/-/bclient-0.1.4.tgz",
+          "integrity": "sha512-1/O/X1iVy1Vxydcuw5zIe/5AERcfUNbV48MPs1g7ZWa0/1Lhve432vgA5OKLQXrHADABF1vuE+ar+mGMKEiOiw==",
+          "dev": true,
+          "requires": {
+            "bcfg": "~0.1.3",
+            "bcurl": "~0.1.3",
+            "bsert": "~0.0.4"
+          }
+        },
         "bcrypto": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-0.3.7.tgz",
-          "integrity": "sha512-ZFeKszFo4abpbzLUK8sqQx87Np5ptaskhszU4Jf9JDFa1Bjuanwrv0a7z1xZJOWNG9abz8krgwvO1Z/NBtsgbg==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-2.0.0.tgz",
+          "integrity": "sha512-j4TtmOQDsaKDV2Xf0ksgsgCQCV2EsH1O8f1vNMOtUiSlGa1RjXCB/iKVu1gErjjeCqchnMaqOXMkiMGT6yeqvQ==",
           "dev": true,
           "requires": {
             "bindings": "~1.3.0",
-            "bn.js": "~4.11.8",
-            "bufio": "~0.2.0",
-            "elliptic": "~6.4.0",
-            "nan": "~2.10.0",
-            "secp256k1": "3.5.0"
+            "bsert": "~0.0.4",
+            "bufio": "~1.0.2",
+            "nan": "~2.11.0"
+          }
+        },
+        "bcurl": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.3.tgz",
+          "integrity": "sha512-l9tG3yH52f0QYwP0g0G6K9fwpOi/1A95D9vIjAcoEMQaGl2jETxvRjiVsxMWBzo0OTwjjAZOc6HyDo1ZbkfI4g==",
+          "dev": true,
+          "requires": {
+            "brq": "~0.1.3",
+            "bsert": "~0.0.4",
+            "bsock": "~0.1.3"
+          }
+        },
+        "bdb": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.1.tgz",
+          "integrity": "sha512-vuzkFcqTSDzZYYckVGUz37sna7KfdkMZ4t+96P3Ohw9z+uUwwakYe3G2G0ErwSLDvP7CadJrYwWtOFpu6ojSEw==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "nan": "~2.11.0"
+          }
+        },
+        "bevent": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.2.tgz",
+          "integrity": "sha512-YOqqEs+hvQ7n/VmxnfxM3jwxYAGcGO1Ls09RTCAsstROi9nVGhSMTnRi5OIPjlT9l+oFdQFUrExPxdSlXj4laQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "blgr": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.2.tgz",
+          "integrity": "sha512-PPX5ULDnOM8Hrky+6SihZQpHniIKp+0RjXVzFI0Ca6533ItHnd6YXU0VbM5VFWZ/dYc7FC74hWPu0j7yYJm2MQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bmutex": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.3.tgz",
+          "integrity": "sha512-VR6fZbVl2/GZOSUy2Cpl7ijVZKP/Ma9JUaGQBSw/xW5lJB7fF2qzmY0BLJ0s0TG+lAY0+1yqPiA3Nj1mlDEUdA==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "brq": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.3.tgz",
+          "integrity": "sha512-3wTf6IXQInJ8MedIuWmFcKL33dce7EZ7fY5aDSxzStSuvuODmpjXqNhxJ8RZ497l9CDA55Eyq1g1fJrT4LSfQQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bsock": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.3.tgz",
+          "integrity": "sha512-XE/xHURZU1jVZ3u7ByLr4ecUWmy/3IePIbf4yBEMA5mpOBgwgyBUEOZg7stjsbx1+3MYjNvE4G1y84WuLELulg==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bstring": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.0.tgz",
+          "integrity": "sha512-sS407Eiha2A4rAXjFgiL1se5w28BYmGmdk6FILWxT2PgWvk0RBBjOk4Eq8dOqRsmHFVatiggGMAz1IP7JjJQsg==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "n64": "~0.2.2",
+            "nan": "~2.11.0"
           }
         },
         "bufio": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
-          "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.2.tgz",
+          "integrity": "sha512-Iy21XxtsPuBNjiny0/h6qIY9uKi91ZCvdbXOLJEV8dAKXE3COxWMfzcXXN3dpSQXhe6FiJ3iBZxzNfpjyPccug==",
+          "dev": true
+        },
+        "bval": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.3.tgz",
+          "integrity": "sha512-DLQAjvVCbAUFVy2jnMyKtk4gjoYyQTXeu61ykPiTEOl/wdzgYGu5gdxvp3cLi6hzZzplOAgGG5zMc6w6+ZzoPA==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bweb": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.4.tgz",
+          "integrity": "sha512-FcqJgkA8SA89KsqEcGo3nr6ZaOP4sobkocQn0vhwcoBrbl8an1vo27/2XazqhHaCuCPr2BhWK6q6ITHc00WGew==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4",
+            "bsock": "~0.1.3"
+          }
+        },
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
           "dev": true
         }
       }
@@ -1537,6 +1659,44 @@
         "nan": "~2.10.0"
       }
     },
+    "bcuckoo": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/bcuckoo/-/bcuckoo-0.6.0.tgz",
+      "integrity": "sha512-caSovdxcgLcqTo0i0cPxUr4SLmUHgStp3NMbjJi+xplsGbsKVjKXFKbAvt55eRxoE3EkJZ9nHG71kSUxWlk/pA==",
+      "dev": true,
+      "requires": {
+        "bcrypto": "~2.0.0",
+        "bsert": "~0.0.4",
+        "bsip": "~0.1.2",
+        "bufio": "~1.0.2"
+      },
+      "dependencies": {
+        "bcrypto": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-2.0.0.tgz",
+          "integrity": "sha512-j4TtmOQDsaKDV2Xf0ksgsgCQCV2EsH1O8f1vNMOtUiSlGa1RjXCB/iKVu1gErjjeCqchnMaqOXMkiMGT6yeqvQ==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "bufio": "~1.0.2",
+            "nan": "~2.11.0"
+          }
+        },
+        "bufio": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.2.tgz",
+          "integrity": "sha512-Iy21XxtsPuBNjiny0/h6qIY9uKi91ZCvdbXOLJEV8dAKXE3COxWMfzcXXN3dpSQXhe6FiJ3iBZxzNfpjyPccug==",
+          "dev": true
+        },
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "dev": true
+        }
+      }
+    },
     "bcurl": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.2.tgz",
@@ -1558,12 +1718,12 @@
       }
     },
     "bdns": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.1.tgz",
-      "integrity": "sha512-XnZAjI4DOlwYW7V4uhekGXOwTmJ3zSZtG5iHybqTPTSFwh1XsxZreXcKLoPZcvBz7v+vqo934JMYPprmtc62lA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.2.tgz",
+      "integrity": "sha512-/b5KwvM5Uxb+CTFN/PjaJttHEcwTDQoZingvJViyQXS61aau4sqMBAZbKaS30ULq9c08sWamUWEnJGSSKq5gcA==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.3"
+        "bsert": "~0.0.4"
       }
     },
     "bevent": {
@@ -1576,36 +1736,37 @@
       }
     },
     "bfile": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.1.1.tgz",
-      "integrity": "sha512-BzQX3loGHgVKfu4KhZ1lI3yaZeBSFar6kKBJNTBCtI+SvYhXn4OALgCxX0C0/9Ca39vjcSkwLhOLMZZGoC0F6g==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.1.2.tgz",
+      "integrity": "sha512-k/GnFlGvy3Pxsko3BLpvyEPdFeSXrsq56fB6Zms8jlsiRv3BFDvzm2DI/RWFZzhEpiGPFjjFA6UamJZVBKUyzQ==",
       "dev": true
     },
     "bfilter": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-0.2.0.tgz",
-      "integrity": "sha512-kQ+LV1FTS3un6iiOqg9qp2kAF+fADZNMZpmv2DHMFIgRSCAjH4NHi9p9X3i34kGJlZzP7+KkySK5it/8/oWKEA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.1.tgz",
+      "integrity": "sha512-x7LXV/y2TPX3YRT0DVW9v7jE7rxlS3jgbM5BmEAihvPrR8v2DICRVTM2FWS2QBL8PciSAYDZxgyyWwJPvOvUdg==",
       "dev": true,
       "requires": {
-        "bufio": "~0.2.0",
-        "mrmr": "~0.1.0"
+        "bsert": "~0.0.4",
+        "bufio": "~1.0.2",
+        "mrmr": "~0.1.2"
       },
       "dependencies": {
         "bufio": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/bufio/-/bufio-0.2.0.tgz",
-          "integrity": "sha512-PjL1QglhgZCWEKWbxzlVB4ExvNorHMu0JSu4ehzeKi38R74Fp7duHAl8xNEqsbJXP5Dfym7XuSEkVol1KX5mhw==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.2.tgz",
+          "integrity": "sha512-Iy21XxtsPuBNjiny0/h6qIY9uKi91ZCvdbXOLJEV8dAKXE3COxWMfzcXXN3dpSQXhe6FiJ3iBZxzNfpjyPccug==",
           "dev": true
         }
       }
     },
     "bheep": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.1.tgz",
-      "integrity": "sha512-kDgcu6BXj/6XsCc+fjjo9ViRETdkQqt0FYxQR+ZqQ4edbWE6x8o51k/BwzqkXWPHrsB2/qLjsgnnMPezJvSnpw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.2.tgz",
+      "integrity": "sha512-Ud+Y5iPGlHMgu2oaYSOPZNBqtUGn+/f7sLrvjpY81mHGDiH5bVDOCp13Wey57pdV6UBzz3L+LpskPRvN1YJ65g==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.3"
+        "bsert": "~0.0.4"
       }
     },
     "big.js": {
@@ -1626,13 +1787,13 @@
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "binet": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.1.tgz",
-      "integrity": "sha512-4ZCsooGoTYG6BwikD1bjXStzhR5wZnc16CA13cm6ot3jsN3Ridrj7G02sL2yzXTegXILIZy25Au+RHqC8F/jzQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.2.tgz",
+      "integrity": "sha512-ZsH2u3HlVgtN0K1XyQO9wLHe8qFpBq4c4tmOK8y83nnm8+VgI6Am365VVgpigwg4zZmMSa9MYfcPWdWWMMrBAA==",
       "dev": true,
       "requires": {
-        "bs32": "~0.1.1",
-        "bsert": "~0.0.3"
+        "bs32": "~0.1.2",
+        "bsert": "~0.0.4"
       }
     },
     "bip66": {
@@ -1664,21 +1825,21 @@
       }
     },
     "blru": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.2.tgz",
-      "integrity": "sha512-S3rvHlFMFYOZT+1gQct44FLIeNjf51RZBUWunuMXb7GDREtI98m6MxBVjdfxYKrdIX5YI8gY4FrVLCq59oQeXQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.3.tgz",
+      "integrity": "sha512-VABNB1X4/9hahUwZL299ogkkob0+oHS65Hx3rKSVs+mUEU1VURhOkkzXxnvOCBSlECSjGHbd88gEc9PiEboDeA==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.3"
+        "bsert": "~0.0.4"
       }
     },
     "blst": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.1.tgz",
-      "integrity": "sha512-avNp9dO3fXFObDYqh8rY12uUenbLLZaySKIKI32Mlq1czTw7Szah9nzQsMh5ejmkBsR3FjUyuWczGzi4o8BVdQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.2.tgz",
+      "integrity": "sha512-R4lsoIwklHXTxGEkp7hhknr0zN41UhGNFsRd5zNJ7Wa67kAFlUFqcMqTpgzbFTZ9S0Cf37hn8OfeBhvFwVtvrg==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.3"
+        "bsert": "~0.0.4"
       }
     },
     "bluebird": {
@@ -1744,6 +1905,50 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
+    },
+    "bns": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/bns/-/bns-0.4.0.tgz",
+      "integrity": "sha512-EASa4FRe1dKQIdk+yv/veP0xtki5vqsAJHzTWTLto8jif+Bfh7M5J3xbM23dfzWJrxHN244H0Mt+bw2hDh2O/w==",
+      "dev": true,
+      "requires": {
+        "bcrypto": "~2.0.0",
+        "bfile": "~0.1.2",
+        "bheep": "~0.1.2",
+        "binet": "~0.3.2",
+        "bs32": "~0.1.2",
+        "bsert": "~0.0.4",
+        "btcp": "~0.1.2",
+        "budp": "~0.1.2",
+        "bufio": "~1.0.2",
+        "unbound": "~0.2.0"
+      },
+      "dependencies": {
+        "bcrypto": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-2.0.0.tgz",
+          "integrity": "sha512-j4TtmOQDsaKDV2Xf0ksgsgCQCV2EsH1O8f1vNMOtUiSlGa1RjXCB/iKVu1gErjjeCqchnMaqOXMkiMGT6yeqvQ==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "bufio": "~1.0.2",
+            "nan": "~2.11.0"
+          }
+        },
+        "bufio": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.2.tgz",
+          "integrity": "sha512-Iy21XxtsPuBNjiny0/h6qIY9uKi91ZCvdbXOLJEV8dAKXE3COxWMfzcXXN3dpSQXhe6FiJ3iBZxzNfpjyPccug==",
+          "dev": true
+        },
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "dev": true
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1972,12 +2177,12 @@
       }
     },
     "bs32": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.1.tgz",
-      "integrity": "sha512-mvHV7pk3ub6jLKpztr2+KMcx4uR2L/9rl5x0BKBgXBmImeILjkTeEjG1ts4gZ302qW/z7mxDf07W9sPovjlHtA==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.2.tgz",
+      "integrity": "sha512-d+6l8lN4OBd2Xp3hGqfRofR0QVztY2cdCyT4eSGjKFnEpEwrCW+h/FvInm13hHmjTqkkrxgdsKyPtvH7pGNV7Q==",
       "dev": true,
       "requires": {
-        "bsert": "~0.0.3"
+        "bsert": "~0.0.4"
       }
     },
     "bsert": {
@@ -1986,14 +2191,22 @@
       "integrity": "sha512-VReLe1aTaHRmf80YLOHUk8ONQ48SjseZP76GlNIDheD5REYByn/Mm9yrtI0/ZCaFrcfxzgpiw1/hMMCUOSMa3w=="
     },
     "bsip": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.1.tgz",
-      "integrity": "sha512-LQdhDedZQuwezVneaojtV7CPJSiDUsVvB+HVIG9BmMi9cEtPC1MKKtRMLNm1HEaXauhc3fTdfCjXnBmPkOcTng==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/bsip/-/bsip-0.1.2.tgz",
+      "integrity": "sha512-Pa3zJIghawS9kyYdmlYBYRMjOueCNSJ41IRwye5T0ptqB42Y91myD5jyf5dI7jcCDXePLAi6lGg1Pv2VsJUL5A==",
       "dev": true,
       "requires": {
         "bindings": "~1.3.0",
-        "bsert": "~0.0.3",
-        "nan": "~2.10.0"
+        "bsert": "~0.0.4",
+        "nan": "~2.11.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "dev": true
+        }
       }
     },
     "bsock": {
@@ -2005,13 +2218,13 @@
       }
     },
     "bsocks": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.1.tgz",
-      "integrity": "sha512-RSoJL6j7C1bw9IHaxiKhEj2iga1TRNyW9EiMpDhfunbMM9xvP5xJ+oVmOCJLE+JEDRdWNESAgOeNZnn3q9fGdg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.2.tgz",
+      "integrity": "sha512-RRs21CTDM2hXt6Aj8rKu0ojzK9dKuJHmrQJstx/bneyhIyRDd+HItR4AbhficfvlcEy2zXUJ7eGypMHsIh91DQ==",
       "dev": true,
       "requires": {
-        "binet": "~0.3.1",
-        "bsert": "~0.0.3"
+        "binet": "~0.3.2",
+        "bsert": "~0.0.4"
       }
     },
     "bstring": {
@@ -2026,9 +2239,15 @@
       }
     },
     "btcp": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.1.tgz",
-      "integrity": "sha512-EwqraaSVjrMYSuSchJ0t2gdeA/4BGgKu+tFVJpTpc4pjzrlu9O6kc3NNffSyIzoxd7jToRdrsT3TorA03a/qwQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.2.tgz",
+      "integrity": "sha512-pLCWOthLQVRkgrVmIjyuL1/NVEhz0lnmgc0I+jm5ZYZ7rkuHYkjmq4qAzqMo/4EYMMAAbdq1CNhuhgVs65nl+A==",
+      "dev": true
+    },
+    "budp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/budp/-/budp-0.1.2.tgz",
+      "integrity": "sha512-bsCXrGylWdiWmEoEq5A8nmtl5/O5jKhYG7XxOc1yLtLPgd2xeEKYlNAgR6Vd45wu+wdl2o6MHOJGjfxqrWotEw==",
       "dev": true
     },
     "buffer": {
@@ -2069,6 +2288,12 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-map": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.3.tgz",
+      "integrity": "sha512-7LgIEyPqfRohq8IfFCyC/aFj+TuoOz3tLstmI+LObSSF0tzI4DoB99/3sdkwIKrr0pLygqIgw/Tn4dt+erdt+Q==",
+      "dev": true
+    },
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -2093,14 +2318,25 @@
       "dev": true
     },
     "bupnp": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.2.tgz",
-      "integrity": "sha512-VauG03WYuZqqP+n/4gf/ItoZPgmSR76whDRFvAYvzsQzotTs3NfIKa7GGlykjAmvOPuuXqa2yVPNGV8dS+MomA==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.3.tgz",
+      "integrity": "sha512-2Q4AAQbpGWr2znRGrwdqjMcl6WzA7/aWtRaFYQWJ3qKxgNdTvPfA68g4/Ie4Bp/N4zBWgvZA0IO8CrEs6/olSQ==",
       "dev": true,
       "requires": {
-        "binet": "~0.3.1",
-        "brq": "~0.1.2",
-        "bsert": "~0.0.3"
+        "binet": "~0.3.2",
+        "brq": "~0.1.3",
+        "bsert": "~0.0.4"
+      },
+      "dependencies": {
+        "brq": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.3.tgz",
+          "integrity": "sha512-3wTf6IXQInJ8MedIuWmFcKL33dce7EZ7fY5aDSxzStSuvuODmpjXqNhxJ8RZ497l9CDA55Eyq1g1fJrT4LSfQQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        }
       }
     },
     "bval": {
@@ -4510,6 +4746,199 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
+    "hs-client": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.2.tgz",
+      "integrity": "sha512-SjDRqoeeoErbZGuFArL/AGQlIC67Y/Jik3Wxd6voB3fysT6u6ZfXVDYVJIitTKET5aCLVqXximNIoFYYZ83TDQ==",
+      "dev": true,
+      "requires": {
+        "bcfg": "~0.1.2",
+        "bcurl": "~0.1.2",
+        "bsert": "~0.0.4"
+      }
+    },
+    "hsd": {
+      "version": "github:handshake-org/hsd#7f6e6ba277f43011fa873338fa693e85d4e3a907",
+      "from": "github:handshake-org/hsd",
+      "dev": true,
+      "requires": {
+        "bcfg": "~0.1.3",
+        "bcrypto": "~2.0.0",
+        "bcuckoo": "~0.6.0",
+        "bdb": "~1.1.1",
+        "bdns": "~0.1.2",
+        "bevent": "~0.1.2",
+        "bfile": "~0.1.2",
+        "bfilter": "~1.0.1",
+        "bheep": "~0.1.2",
+        "binet": "~0.3.2",
+        "blgr": "~0.1.2",
+        "blru": "~0.1.3",
+        "blst": "~0.1.2",
+        "bmutex": "~0.1.3",
+        "bns": "~0.4.0",
+        "bs32": "~0.1.2",
+        "bsert": "~0.0.4",
+        "bsip": "~0.1.2",
+        "bsock": "~0.1.3",
+        "bsocks": "~0.2.2",
+        "bstring": "~0.3.0",
+        "btcp": "~0.1.2",
+        "buffer-map": "~0.0.3",
+        "bufio": "~1.0.2",
+        "bupnp": "~0.2.3",
+        "bval": "~0.1.3",
+        "bweb": "~0.1.4",
+        "hs-client": "~0.0.3",
+        "mrmr": "~0.1.2",
+        "n64": "~0.2.2",
+        "urkel": "~0.6.0"
+      },
+      "dependencies": {
+        "bcfg": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.3.tgz",
+          "integrity": "sha512-N/ZpKumfVYcAE5nYc0t4guvMGmtFaFn2QLUVZ0+0e1DBoRR7U6uh94pES7d2R7BKiYuVN1EI9bgOGmWGK4Kvig==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bcrypto": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-2.0.0.tgz",
+          "integrity": "sha512-j4TtmOQDsaKDV2Xf0ksgsgCQCV2EsH1O8f1vNMOtUiSlGa1RjXCB/iKVu1gErjjeCqchnMaqOXMkiMGT6yeqvQ==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "bufio": "~1.0.2",
+            "nan": "~2.11.0"
+          }
+        },
+        "bcurl": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.3.tgz",
+          "integrity": "sha512-l9tG3yH52f0QYwP0g0G6K9fwpOi/1A95D9vIjAcoEMQaGl2jETxvRjiVsxMWBzo0OTwjjAZOc6HyDo1ZbkfI4g==",
+          "dev": true,
+          "requires": {
+            "brq": "~0.1.3",
+            "bsert": "~0.0.4",
+            "bsock": "~0.1.3"
+          }
+        },
+        "bdb": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.1.1.tgz",
+          "integrity": "sha512-vuzkFcqTSDzZYYckVGUz37sna7KfdkMZ4t+96P3Ohw9z+uUwwakYe3G2G0ErwSLDvP7CadJrYwWtOFpu6ojSEw==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "nan": "~2.11.0"
+          }
+        },
+        "bevent": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.2.tgz",
+          "integrity": "sha512-YOqqEs+hvQ7n/VmxnfxM3jwxYAGcGO1Ls09RTCAsstROi9nVGhSMTnRi5OIPjlT9l+oFdQFUrExPxdSlXj4laQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "blgr": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.1.2.tgz",
+          "integrity": "sha512-PPX5ULDnOM8Hrky+6SihZQpHniIKp+0RjXVzFI0Ca6533ItHnd6YXU0VbM5VFWZ/dYc7FC74hWPu0j7yYJm2MQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bmutex": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.3.tgz",
+          "integrity": "sha512-VR6fZbVl2/GZOSUy2Cpl7ijVZKP/Ma9JUaGQBSw/xW5lJB7fF2qzmY0BLJ0s0TG+lAY0+1yqPiA3Nj1mlDEUdA==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "brq": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.3.tgz",
+          "integrity": "sha512-3wTf6IXQInJ8MedIuWmFcKL33dce7EZ7fY5aDSxzStSuvuODmpjXqNhxJ8RZ497l9CDA55Eyq1g1fJrT4LSfQQ==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bsock": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.3.tgz",
+          "integrity": "sha512-XE/xHURZU1jVZ3u7ByLr4ecUWmy/3IePIbf4yBEMA5mpOBgwgyBUEOZg7stjsbx1+3MYjNvE4G1y84WuLELulg==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bstring": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/bstring/-/bstring-0.3.0.tgz",
+          "integrity": "sha512-sS407Eiha2A4rAXjFgiL1se5w28BYmGmdk6FILWxT2PgWvk0RBBjOk4Eq8dOqRsmHFVatiggGMAz1IP7JjJQsg==",
+          "dev": true,
+          "requires": {
+            "bindings": "~1.3.0",
+            "bsert": "~0.0.4",
+            "n64": "~0.2.2",
+            "nan": "~2.11.0"
+          }
+        },
+        "bufio": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.2.tgz",
+          "integrity": "sha512-Iy21XxtsPuBNjiny0/h6qIY9uKi91ZCvdbXOLJEV8dAKXE3COxWMfzcXXN3dpSQXhe6FiJ3iBZxzNfpjyPccug==",
+          "dev": true
+        },
+        "bval": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.3.tgz",
+          "integrity": "sha512-DLQAjvVCbAUFVy2jnMyKtk4gjoYyQTXeu61ykPiTEOl/wdzgYGu5gdxvp3cLi6hzZzplOAgGG5zMc6w6+ZzoPA==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        },
+        "bweb": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.4.tgz",
+          "integrity": "sha512-FcqJgkA8SA89KsqEcGo3nr6ZaOP4sobkocQn0vhwcoBrbl8an1vo27/2XazqhHaCuCPr2BhWK6q6ITHc00WGew==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4",
+            "bsock": "~0.1.3"
+          }
+        },
+        "hs-client": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.3.tgz",
+          "integrity": "sha512-FaH8Ly1tcAD27Y94WPJwrsjs7Z4MIvRa7SRWTuUKni/L5f/sagH4PPKcM4zhlslOP+8kUzX20CM+yUO+YZuPMw==",
+          "dev": true,
+          "requires": {
+            "bcfg": "~0.1.3",
+            "bcurl": "~0.1.3",
+            "bsert": "~0.0.4"
+          }
+        },
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "dev": true
+        }
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -5594,14 +6023,22 @@
       }
     },
     "mrmr": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.1.tgz",
-      "integrity": "sha512-2nJ8KlBZiFsj629GsqSBfx/ILWpL3+Kam8eMBn/YL84lvPUuAG0SNvtaGr8Z7T19wKOYnJAV5N+MCEXVgguxtQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.2.tgz",
+      "integrity": "sha512-Mp9g9pOJzR8sQT4hZhji4rICLM7FiJOfIvSuAYo8bRnWt3h4UuU0FNJFWuaOBKI+EJos0KVsVE3ddrewTrsVSg==",
       "dev": true,
       "requires": {
         "bindings": "~1.3.0",
-        "bsert": "~0.0.3",
-        "nan": "~2.10.0"
+        "bsert": "~0.0.4",
+        "nan": "~2.11.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -5617,9 +6054,9 @@
       "dev": true
     },
     "n64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.1.tgz",
-      "integrity": "sha512-rs7dj53A2qK/bk4gQnBAp3DYwtyHKs5y2tbuQkgM4mDwGBI7fPJBbfBaXaNOpbVtnru2Aw++qVCNDYJ3XAuc7A==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.2.tgz",
+      "integrity": "sha512-GZwT9n1Il1T4v+CKlefieFcaq7rubLTsqbGIBtXpt8rDMhw/ZmjJMdoj0hT/Qk86uSYnQ/RisRHp4ZmPS2Qfjw==",
       "dev": true
     },
     "nan": {
@@ -7761,6 +8198,26 @@
       "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
       "dev": true
     },
+    "unbound": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.2.0.tgz",
+      "integrity": "sha512-+lMzvF+N3h7frrtYnSk8u3ehRa7Bnplrn+SsBtjPm2ditigjqi4rb1X1yOWz/WReh3W2MqFrMMvjPLTO6wF4bQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "~1.3.0",
+        "nan": "~2.11.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "undeclared-identifiers": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.2.tgz",
@@ -7900,6 +8357,28 @@
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
+    },
+    "urkel": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/urkel/-/urkel-0.6.0.tgz",
+      "integrity": "sha512-wFeMuItf4dhQurP6V6w4mJXrOnV6+5iTzNgqy/j9wqs920JGr942/xTFGXKgXpRmXPveBq/D4AtJOWj0HpT5Hg==",
+      "dev": true,
+      "requires": {
+        "bfile": "~0.1.2",
+        "bmutex": "~0.1.3",
+        "bsert": "~0.0.4"
+      },
+      "dependencies": {
+        "bmutex": {
+          "version": "0.1.3",
+          "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.3.tgz",
+          "integrity": "sha512-VR6fZbVl2/GZOSUy2Cpl7ijVZKP/Ma9JUaGQBSw/xW5lJB7fF2qzmY0BLJ0s0TG+lAY0+1yqPiA3Nj1mlDEUdA==",
+          "dev": true,
+          "requires": {
+            "bsert": "~0.0.4"
+          }
+        }
+      }
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -34,14 +34,14 @@
     "bcoin": "github:bcoin-org/bcoin.git",
     "bclient": "^0.1.3",
     "bmultisig": "^0.0.3",
-    "hsd": "handshake-org/hsd",
+    "hsd": "github:handshake-org/hsd",
     "hs-client": "0.0.2"
   },
   "devDependencies": {
     "bcoin": "github:bcoin-org/bcoin.git",
     "bclient": "^0.1.3",
     "bmultisig": "^0.0.3",
-    "hsd": "handshake-org/hsd",
+    "hsd": "github:handshake-org/hsd.git",
     "hs-client": "0.0.2",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,18 @@
     "moment": "^2.22.2"
   },
   "peerDependencies": {
-    "bcoin": "git+https://github.com/bcoin-org/bcoin.git",
+    "bcoin": "github:bcoin-org/bcoin.git",
     "bclient": "^0.1.3",
     "bmultisig": "^0.0.3",
     "hsd": "handshake-org/hsd",
     "hs-client": "0.0.2"
   },
   "devDependencies": {
+    "bcoin": "github:bcoin-org/bcoin.git",
+    "bclient": "^0.1.3",
+    "bmultisig": "^0.0.3",
+    "hsd": "handshake-org/hsd",
+    "hs-client": "0.0.2",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.3",
@@ -49,8 +54,6 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
     "babelify": "^8.0.0",
-    "bclient": "^0.1.3",
-    "bmultisig": "^0.0.3",
     "browserify": "^14.5.0",
     "chai": "^4.1.2",
     "eslint": "^4.14.0",

--- a/test/currency-test.js
+++ b/test/currency-test.js
@@ -1,0 +1,58 @@
+import { assert } from 'chai';
+import Currency, { CURRENCY_TYPES, CURRENCY_UNITS } from '../lib/currency';
+import { Amount, pkg } from 'hsd';
+
+describe.only('Currency', () => {
+  let bitcoin, bitcoinCash, handshake, baseAmt;
+  beforeEach(() => {
+    baseAmt = 5;
+    bitcoin = new Currency('bitcoin', 5);
+    bitcoinCash = new Currency('bitcoincash', 5);
+    handshake = new Currency('handshake', 5);
+  });
+
+  it('should be an instance of HSD Amount class', () => {
+    assert.instanceOf(handshake, Amount);
+    assert.instanceOf(bitcoin, Amount);
+    assert.instanceOf(bitcoinCash, Amount);
+  });
+
+  it('should return matching units for Handshake', () => {
+    assert.equal(handshake.getUnit(CURRENCY_TYPES.base), pkg.base);
+    assert.equal(handshake.getUnit(CURRENCY_TYPES.micro), `u${pkg.unit}`);
+    assert.equal(handshake.getUnit(CURRENCY_TYPES.milli), `m${pkg.unit}`);
+    assert.equal(handshake.getUnit(CURRENCY_TYPES.unit), pkg.unit);
+    assert.equal(handshake.getUnit(CURRENCY_TYPES.currency), pkg.currency);
+  });
+
+  it('should return correct units for Bitcoin and Bitcoin Cash', () => {
+    const currencies = [bitcoin, bitcoinCash];
+    currencies.forEach(currency => {
+      assert.equal(currency.getUnit(CURRENCY_TYPES.base), 'satoshi');
+      assert.equal(currency.getUnit(CURRENCY_TYPES.micro), 'bit');
+      assert.equal(currency.getUnit(CURRENCY_TYPES.milli), 'mbtc');
+      assert.equal(currency.getUnit(CURRENCY_TYPES.unit), 'btc');
+      assert.equal(currency.getUnit(CURRENCY_TYPES.currency), 'bitcoin');
+    });
+  });
+
+  it('should convert values to and from the correct units', () => {
+    const currencies = Object.keys(CURRENCY_UNITS);
+    const coins = { bitcoin, handshake, bitcoinCash };
+    for (let currency of currencies) {
+      for (let type in CURRENCY_TYPES) {
+        const val = Currency.from(currency, CURRENCY_TYPES[type], baseAmt);
+        assert.equal(
+          val.to(CURRENCY_TYPES[type], true),
+          coins['handshake'].toBase(true),
+          `Problem with ${type}`
+        );
+      }
+    }
+  });
+
+  it('should throw on unknown chain', () => {
+    const createUnknownCurrency = () => new Currency('foobar');
+    assert.throws(createUnknownCurrency);
+  });
+});

--- a/test/currency-test.js
+++ b/test/currency-test.js
@@ -6,7 +6,7 @@ import Currency, {
 } from '../lib/currency';
 import { Amount, pkg } from 'hsd';
 
-describe.only('Currency', () => {
+describe('Currency', () => {
   let bitcoin, bitcoinCash, handshake, baseAmt;
   beforeEach(() => {
     baseAmt = 5;

--- a/test/currency-test.js
+++ b/test/currency-test.js
@@ -1,5 +1,9 @@
 import { assert } from 'chai';
-import Currency, { CURRENCY_TYPES, CURRENCY_UNITS } from '../lib/currency';
+import Currency, {
+  CURRENCY_TYPES,
+  CURRENCY_UNITS,
+  CHAIN_EXP,
+} from '../lib/currency';
 import { Amount, pkg } from 'hsd';
 
 describe.only('Currency', () => {
@@ -34,6 +38,26 @@ describe.only('Currency', () => {
       assert.equal(currency.getUnit(CURRENCY_TYPES.unit), 'btc');
       assert.equal(currency.getUnit(CURRENCY_TYPES.currency), 'bitcoin');
     });
+  });
+
+  it('should convert to correct milli units', () => {
+    const bitcoinExp = CHAIN_EXP['bitcoin'] - 3;
+    const hnsExp = CHAIN_EXP['handshake'] - 3;
+    assert.equal(
+      bitcoin.toMilli(true),
+      Currency.encode(baseAmt, bitcoinExp, true),
+      'Problem with `toMilli` for bitcoin'
+    );
+    assert.equal(
+      bitcoinCash.toMilli(true),
+      Currency.encode(baseAmt, bitcoinExp, true),
+      'Problem with `toMilli` for bitcoinCash'
+    );
+    assert.equal(
+      handshake.toMilli(true),
+      Currency.encode(baseAmt, hnsExp, true),
+      'Problem with `toMilli` for handshake'
+    );
   });
 
   it('should convert values to and from the correct units', () => {


### PR DESCRIPTION
Utilities for getting currency descriptors. Extends `Amount` from hsd to make other currency related utilities available but abstracts out chain specific names.

Includes tests but for "real world" use case, see simple-wallet [PR 16](https://github.com/bpanel-org/simple-wallet/pull/16)