### PR TITLE
chain: getblockheader if SPV

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -31,17 +31,38 @@ export const getBlock = hashOrHeight => {
  * @param {boolean=false} [details] - true for tx details
  * @returns {Promise}
  */
-export const getBlockInfo = (hashOrHeight, verbose=true, details=false) => {
+export const getBlockInfo = async (hashOrHeight, verbose=true, details=false) => {
   const client = getClient();
   try {
+    let blockInfo;
     if (typeof hashOrHeight === 'number')
-      return client.node.execute('getblockbyheight', [hashOrHeight, verbose, details]);
+      blockInfo = await client.node.execute('getblockbyheight', [hashOrHeight, verbose, details]);
     if (typeof hashOrHeight === 'string')
-      return client.node.execute('getblock', [hashOrHeight, verbose, details]);
+      blockInfo = await client.node.execute('getblock', [hashOrHeight, verbose, details]);
     throw new Error('Must pass either string for block hash or number for block height');
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('There was a problem retrieving block: ', e);
+
+    try {
+      // If we're in SPV mode, try and get the block header
+      let hash = hashOrHeight;
+      if (typeof hashOrHeight === 'number') {
+        hash = await client.node.execute('getblockhash', [hashOrHeight]);
+      }
+      let blockHeader = await client.node.execute('getblockheader', [hash, true]);
+      // stay compatible with get full block data above
+      blockHeader = {
+        ...blockHeader,
+        strippedsize: 0,
+        size: 0,
+        weight: 0,
+        tx: [],
+      };
+      return blockHeader;
+    } catch(e2) {
+      // eslint-disable-next-line no-console
+      console.error('There was a problem retrieving blockheader: ', e2);
+    }
+
   }
 }
 


### PR DESCRIPTION
1) added async/await to the RPC calls
2) added second try/catch block that executes SPV-friendly versions of the `getBlock` commands (ie `getBlockHeader`)
3) adds `0` values in to the object to match the "full node" shape (size and txs)

<img width="1185" alt="screen shot 2018-12-11 at 5 16 45 pm" src="https://user-images.githubusercontent.com/2084648/49840517-90a5a100-fd68-11e8-81b6-cb51e4338f94.png">
