### PR TITLE
chain: support SPV by getting headers instead of blocks

### DIFF
--- a/lib/chain.js
+++ b/lib/chain.js
@@ -31,38 +31,36 @@ export const getBlock = hashOrHeight => {
  * @param {boolean=false} [details] - true for tx details
  * @returns {Promise}
  */
-export const getBlockInfo = async (hashOrHeight, verbose=true, details=false) => {
+export const getBlockInfo = (hashOrHeight, verbose=true, details=false) => {
   const client = getClient();
   try {
-    let blockInfo;
     if (typeof hashOrHeight === 'number')
-      blockInfo = await client.node.execute('getblockbyheight', [hashOrHeight, verbose, details]);
+      return client.node.execute('getblockbyheight', [hashOrHeight, verbose, details]);
     if (typeof hashOrHeight === 'string')
-      blockInfo = await client.node.execute('getblock', [hashOrHeight, verbose, details]);
+      return client.node.execute('getblock', [hashOrHeight, verbose, details]);
     throw new Error('Must pass either string for block hash or number for block height');
   } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('There was a problem retrieving block: ', e);
+  }
+}
 
-    try {
-      // If we're in SPV mode, try and get the block header
-      let hash = hashOrHeight;
-      if (typeof hashOrHeight === 'number') {
-        hash = await client.node.execute('getblockhash', [hashOrHeight]);
-      }
-      let blockHeader = await client.node.execute('getblockheader', [hash, true]);
-      // stay compatible with get full block data above
-      blockHeader = {
-        ...blockHeader,
-        strippedsize: 0,
-        size: 0,
-        weight: 0,
-        tx: [],
-      };
-      return blockHeader;
-    } catch(e2) {
-      // eslint-disable-next-line no-console
-      console.error('There was a problem retrieving blockheader: ', e2);
+/*
+ * SPV equivalent to getBlockInfo above
+ */
+export const getBlockHeaderInfo = async (hashOrHeight, verbose=true, details=false) => {
+  const client = getClient();
+  try {
+    // If we're in SPV mode, try and get the block header
+    let hash = hashOrHeight;
+    if (typeof hashOrHeight === 'number') {
+      hash = await client.node.execute('getblockhash', [hashOrHeight]);
     }
-
+    const blockHeader = await client.node.execute('getblockheader', [hash, true]);
+    return blockHeader;
+  } catch(e) {
+    // eslint-disable-next-line no-console
+    console.error('There was a problem retrieving block header: ', e);
   }
 }
 
@@ -72,8 +70,8 @@ export function calcProgress(start, tip) {
   return Math.min(1, current / end);
 }
 
-// utility to get a range of blocks
-export async function getBlocksInRange(start, end, step = 1) {
+// utility to get a range of blocks (or just headers, in SPV mode)
+export async function getBlocksInRange(start, end, step = 1, SPV = false) {
   // get all blocks from blockHeight `start` up to `start`+ n
   // create an array of the blocks
   const blocks = [];
@@ -84,7 +82,10 @@ export async function getBlocksInRange(start, end, step = 1) {
     assert(step > 0, 'Step needs to be greater than zero to count up');
     while (height < end) {
       try {
-        const block = await getBlockInfo(height);
+        const block =
+          SPV ?
+            await getBlockHeaderInfo(height) :
+            await getBlockInfo(height);
         blocks.push(block);
         height += step;
       } catch (e) {
@@ -103,7 +104,10 @@ export async function getBlocksInRange(start, end, step = 1) {
     }
     while (height > end) {
       try {
-        const block = await getBlockInfo(height);
+        const block =
+          SPV ?
+            await getBlockHeaderInfo(height) :
+            await getBlockInfo(height);;
         blocks.push(block);
         height += _step;
       } catch (e) {

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -31,17 +31,38 @@ export const getBlock = hashOrHeight => {
  * @param {boolean=false} [details] - true for tx details
  * @returns {Promise}
  */
-export const getBlockInfo = (hashOrHeight, verbose=true, details=false) => {
+export const getBlockInfo = async (hashOrHeight, verbose=true, details=false) => {
   const client = getClient();
   try {
+    let blockInfo;
     if (typeof hashOrHeight === 'number')
-      return client.node.execute('getblockbyheight', [hashOrHeight, verbose, details]);
+      blockInfo = await client.node.execute('getblockbyheight', [hashOrHeight, verbose, details]);
     if (typeof hashOrHeight === 'string')
-      return client.node.execute('getblock', [hashOrHeight, verbose, details]);
+      blockInfo = await client.node.execute('getblock', [hashOrHeight, verbose, details]);
     throw new Error('Must pass either string for block hash or number for block height');
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('There was a problem retrieving block: ', e);
+
+    try {
+      // If we're in SPV mode, try and get the block header
+      let hash = hashOrHeight;
+      if (typeof hashOrHeight === 'number') {
+        hash = await client.node.execute('getblockhash', [hashOrHeight]);
+      }
+      let blockHeader = await client.node.execute('getblockheader', [hash, true]);
+      // stay compatible with get full block data above
+      blockHeader = {
+        ...blockHeader,
+        strippedsize: 0,
+        size: 0,
+        weight: 0,
+        tx: [],
+      };
+      return blockHeader;
+    } catch(e2) {
+      // eslint-disable-next-line no-console
+      console.error('There was a problem retrieving blockheader: ', e2);
+    }
+
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,11 +51,12 @@ class BPClient extends Client {
     this.init();
   }
 
-  init() {
+  async init() {
     if (this.id) {
       this.setNodeClient();
       this.setWalletClient();
       this.setMultisigClient();
+      await this.isSPV();
     }
     return this;
   }
@@ -79,7 +80,7 @@ class BPClient extends Client {
    * 'bitcoincash', or 'handshake'
    * @returns {BPClient}
    */
-  setClientInfo(id, chain) {
+  async setClientInfo(id, chain) {
     assert(id && typeof id === 'string');
     this.id = id;
     if (chain) {
@@ -94,6 +95,7 @@ class BPClient extends Client {
     this.setNodeClient();
     this.setWalletClient();
     this.setMultisigClient();
+    await this.isSPV();
 
     this.emit('set clients', { id: this.id, chain: this.chain });
     return this;
@@ -224,6 +226,19 @@ class BPClient extends Client {
       paths[type] = `/clients/${id}/${type}`;
       return paths;
     }, {});
+  }
+
+  /*
+   * Until bcoin, bcash and hsd return SPV flags in `info` we need to test
+   */
+  async isSPV() {
+    try {
+      await this.node.getBlock(0);
+      this.SPV = false;
+    } catch (e) {
+      console.error('SPV test:', e);
+      this.SPV = true;
+    }
   }
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -236,7 +236,6 @@ class BPClient extends Client {
       await this.node.getBlock(0);
       this.SPV = false;
     } catch (e) {
-      console.error('SPV test:', e);
       this.SPV = true;
     }
   }


### PR DESCRIPTION
Adds `isSPV()` to `BPClient` object that stores a bool in `client.SPV` after a block-retrieval test.

Adds new method `getBlockHeaderInfo()` in `chain.js` to match `getBlockInfo()`
`getBlocksInRange()` modified to accept additional param `SPV` and will return either full block info or headers-only depending (it is up to the plugin to know which to ask for)

Stay tuned for a recent-blocks PR...!