### PR TITLE
add bcurlClient to fetch JSON from new curl endpoint in bPanel

### DIFF
--- a/lib/clients.js
+++ b/lib/clients.js
@@ -9,15 +9,24 @@
 import assert from 'bsert';
 import { NodeClient, WalletClient } from 'bclient';
 import { Client as MultisigClient } from 'bmultisig';
+import { Client as CurlClient } from 'bcurl';
 
 import BPClient from './client';
 
-export const { bpanelPort, ssl, nodePath, walletPath, hostname } = options();
+export const {
+  bpanelPort,
+  ssl,
+  nodePath,
+  walletPath,
+  curlPath,
+  hostname
+} = options();
 
 let nodeClient = null;
 let walletClient = null;
 let multisigClient = null;
 let bpClient = null;
+let curlClient = null;
 
 function getClient(id, chain='bitcoin') {
   if (!bpClient) {
@@ -68,10 +77,23 @@ function bmultisigClient() {
   return multisigClient;
 }
 
+function bcurlClient() {
+  if (!curlClient)
+    curlClient = new CurlClient({
+      port: bpanelPort,
+      path: curlPath,
+      host: hostname,
+      ssl
+    });
+
+  return curlClient;
+}
+
 function options() {
   // bpanel endpoints
   const nodePath = '/bcoin';
   const walletPath = '/bwallet';
+  const curlPath = '/curl';
   // determine the port and ssl usage
   const protocol = window.location.protocol;
   const hostname = window.location.hostname;
@@ -85,8 +107,9 @@ function options() {
     ssl,
     hostname,
     nodePath,
-    walletPath
+    walletPath,
+    curlPath
   };
 }
 
-export { bpanelClient, bwalletClient, bmultisigClient, getClient };
+export { bpanelClient, bwalletClient, bmultisigClient, getClient, bcurlClient };

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ export { bpanelClient } from './clients';
 export { bwalletClient } from './clients';
 export { bmultisigClient } from './clients';
 export { getClient } from './clients';
+export { bcurlClient } from './clients';
 export { default as chain } from './chain';
 export { default as helpers } from './helpers';
 export { default as plugins } from './plugins';


### PR DESCRIPTION
see: https://github.com/bpanel-org/bpanel/pull/158

Adds a new `bcurl` based client with no extensions, just used to access remote JSON API data using the bPanel server as a proxy to avoid CORS errors. Grabs stuff like `protocol` and `hostname` from the neighboring `options()` function.