### PR TITLE
primitives: add and expose wrappers for dynamic switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ is a bcoin primitive.
 ```js
 // create a bitcoin mtx
 const hex = Buffer.from('...', 'hex');
-// first argument comes shares properties of objects returned
+// first argument shares properties of objects returned
 // by bcoin backend. second argument is the options
 const mtx = toMTX({ hex }, { type: 'raw', chain: 'bitcoin' });
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ const wallet = walletClient.wallet(id);
 
 /*
  * try fetching the hash yourself
- * curl -s https://blockchain.info/rawblock/0000000000000000000c76fd257881891a21a018c4abd13c33c9f06a822914c9 \
- *   | jq -r .tx[0].hash
+   curl -s https://blockchain.info/rawblock/0000000000000000000c76fd257881891a21a018c4abd13c33c9f06a822914c9 \
+     | jq -r .tx[0].hash
  */
 
 const hash = '6b3aafbed09f215d1f95fb06b7c204d12f7657e1bc1ff3dfa37d3248e05a430c';
@@ -183,6 +183,30 @@ const client = getClient();
 
   console.log('info: ', info);
 })();
+```
+
+#### Primitives
+
+A high level goal of bPanel is to allow for many different blockchain
+backends. To allow for dynamic switching of chains when implementing
+logic with primitives, it is possible to use objects that are keyed
+by the blockchain name to the primitive. These objects are wrapped
+with some helper functions that work via the primitive `from` methods.
+Each of the exposed functions are named `toPrimitive` where primitive
+is a bcoin primitive.
+
+```js
+// create a bitcoin mtx
+const hex = Buffer.from('...', 'hex');
+// first argument comes shares properties of objects returned
+// by bcoin backend. second argument is the options
+const mtx = toMTX({ hex }, { type: 'raw', chain: 'bitcoin' });
+
+// create a bitcoin cash mtx
+const bchmtx = toMTX({ hex }, { type: 'raw', chain: 'bitcoincash' });
+
+const hns = Buffer.from('...', 'hex');
+const hnsmtx = toMTX({ hex: hns }, { type: 'raw', chain: 'handshake' });
 ```
 
 #### Bytes

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,17 @@ export { default as ProxySocket } from './proxysocket';
 export { TxManager, TxManagerOptions } from './txManager';
 
 // UXTX extends MTX
-export { UXTX, UXTXOptions  } from './uxtx';
+export { UXTX, UXTXOptions } from './uxtx';
 
 // constants for wallet development
 export { COIN_TYPES, PURPOSE } from './hd';
+
+// primitive wrappers for dynamic switching
+// between blockchains
+export {
+  toMTX,
+  toTX,
+  toAddress,
+  toKeyRing,
+  toHDPublicKey,
+} from './primitives';

--- a/lib/primitives.js
+++ b/lib/primitives.js
@@ -66,6 +66,16 @@ const HDPublicKey = {
   handshake: hsdHDPublicKey,
 };
 
+// export an object of all
+// of the primities
+export const primitives = {
+  HDPublicKey,
+  MTX,
+  TX,
+  KeyRing,
+  Address,
+};
+
 /*
  * create MTX object
  * @param {Object} tx

--- a/lib/primitives.js
+++ b/lib/primitives.js
@@ -1,0 +1,209 @@
+import assert from 'bsert';
+
+/*
+ * manages mappings between primitives
+ * such that applications can live switch between
+ * different blockchains
+ *
+ */
+
+import {
+  MTX as bcoinMTX,
+  TX as bcoinTX,
+  KeyRing as bcoinKeyRing,
+  Address as bcoinAddress,
+  HDPublicKey as bcoinHDPublicKey,
+} from 'bcoin';
+
+import {
+  MTX as bcashMTX,
+  TX as bcashTX,
+  KeyRing as bcashKeyRing,
+  Address as bcashAddress,
+  HDPublicKey as bcashHDPublicKey,
+} from 'bcash';
+
+import {
+  MTX as hsdMTX,
+  TX as hsdTX,
+  KeyRing as hsdKeyRing,
+  Address as hsdAddress,
+  HDPublicKey as hsdHDPublicKey,
+} from 'hsd';
+
+/*
+ * an object is created for each primitive
+ * that is keyed by the name of the blockchain
+ */
+
+const MTX = {
+  bitcoin: bcoinMTX,
+  bitcoincash: bcashMTX,
+  handshake: hsdMTX,
+};
+
+const TX = {
+  bitcoin: bcoinTX,
+  bitcoincash: bcashTX,
+  handshake: hsdTX,
+};
+
+const Address = {
+  bitcoin: bcoinAddress,
+  bitcoincash: bcashAddress,
+  handshake: hsdAddress,
+};
+
+const KeyRing = {
+  bitcoin: bcoinKeyRing,
+  bitcoincash: bcashKeyRing,
+  handshake: hsdKeyRing,
+};
+
+const HDPublicKey = {
+  bitcoin: bcoinHDPublicKey,
+  bitcoincash: bcashHDPublicKey,
+  handshake: hsdHDPublicKey,
+};
+
+/*
+ * create MTX object
+ * @param {Object} tx
+ * @param {Object} options
+ * @param {String} options.type
+ *   select how to instantiate primitive
+ *   ie, fromRaw, fromJSON etc
+ * @param {String} options.chain
+ *   blockchain name
+ */
+export function toMTX(tx, options) {
+  const { type, chain } = options;
+  assert(type);
+  assert(chain);
+
+  switch (type) {
+    case 'raw':
+      return MTX[chain].fromRaw(tx.hex, 'hex');
+
+    case 'json':
+      return MTX[chain].fromJSON(tx);
+
+    default:
+      return null;
+  }
+}
+
+/*
+ * create TX object
+ * @param {Object} tx
+ * @param {Object} options
+ * @param {String} options.type
+ *   select how to instantiate primitive
+ *   ie, fromRaw, fromJSON etc
+ * @param {String} options.chain
+ *   blockchain name
+ */
+export function toTX(tx, options) {
+  const { type, chain } = options;
+  assert(type);
+  assert(chain);
+
+  switch (type) {
+    case 'raw':
+      return TX[chain].fromRaw(tx.hex, 'hex');
+
+    case 'json':
+      return TX[chain].fromJSON(tx);
+
+    case 'options':
+      return TX[chain].fromOptions(tx);
+
+    default:
+      return null;
+  }
+}
+
+
+/*
+ * create Address object
+ * @param {string} address
+ * @param {Object} options
+ * @param {String} options.type
+ *   select how to instantiate primitive
+ *   ie fromRaw, fromJSON etc
+ * @param {String} options.chain
+ *   blockchain name
+ * @param {String} options.network
+ *   blockchain network
+ *   ie main, testnet, regtest
+ */
+export function toAddress(address, options) {
+  const { type, chain, network } = options;
+
+  switch (type) {
+    case 'string':
+      return Address[chain].fromString(address, network);
+
+    case 'options':
+      return Address[chain].fromOptions(options);
+
+    default:
+      return null;
+  }
+}
+
+
+/*
+ * create Keyring object
+ * @param {string} key
+ * @param {Object} options
+ * @param {String} options.type
+ *   select how to instantiate primitive
+ *   ie fromRaw, fromJSON etc
+ * @param {String} options.chain
+ *   blockchain name
+ * @param {String} options.network
+ *   blockchain network
+ *   ie main, testnet, regtest
+ */
+export function toKeyRing(key, options) {
+  const { type, chain, network, compress } = options;
+
+  switch (type) {
+    case 'public':
+      return KeyRing[chain].fromPublic(key, network);
+
+    case 'private':
+      return KeyRing[chain].fromPrivate(key, compress);
+
+    case 'options':
+      return KeyRing[chain].fromOptions(options);
+
+    default:
+      return null;
+  }
+}
+
+/*
+ * create HDPublicKey object
+ * @param {Object} options
+ * @param {String} options.type
+ *   select how to instantiate primitive
+ *   ie fromRaw, fromJSON etc
+ * @param {String} options.chain
+ *   blockchain name
+ * @param {String} options.network
+ *   blockchain network
+ *   ie main, testnet, regtest
+ */
+export function toHDPublicKey(options) {
+  const { type, chain, xpubkey, network } = options;
+
+  switch (type) {
+    case 'base58':
+      return HDPublicKey[chain].fromBase58(xpubkey, network);
+
+    default:
+      return null;
+  }
+}

--- a/lib/uxtx.js
+++ b/lib/uxtx.js
@@ -1,663 +1,714 @@
-const { Amount, TX } = require('bcoin/lib/bcoin-browser');
-const assert = require('bsert');
-const moment = require('moment');
+// TODO: replace Amount with currency tool
+import { Amount } from 'bcoin';
+import { primitives } from './primitives';
+import assert from 'bsert';
+import moment from 'moment';
 
 /**
  * User Experience Transaction
  * NOTE: this class is not meant to be mutable
  *
+ * instantiate with the static method
+ * fromOptions to allow for dynamic subclassing
+ *
  * @alias module:bpanel-utils.UXTX
- * @extends TX
  */
-class UXTX extends TX {
-  /**
-   * Create a UXTX
-   * User Experience Transaction
-   * @constructor
-   * @param options
-   *
-   * TODO: handle these cases:
-   * wallet/account -> same wallet/account
-   * wallet/account -> same wallet/different account
-   * coinjoin transactions
-   *
-   * TODO: overwrite TX.inspect
-   */
-
-  constructor(options) {
-    super();
-
-    // these are used as keys to look up
-    // in options.labels for toJSON labels
-    this.TYPES = {
-      COINBASE: 'COINBASE',
-      WITHDRAW: 'WITHDRAW',
-      DEPOSIT: 'DEPOSIT',
-      UNKNOWN: 'UNKNOWN',
+class UXTX {
+  constructor(options, SuperClass) {
+    /*
+     * this class inherits from bcoin like
+     * TX primitive, for dynamic subclassing,
+     * pass in a SuperClass or automatically
+     * determine SuperClass based on chain
+     */
+    if (!SuperClass) {
+      let chain;
+      if (options && options.chain) chain = options.chain;
+      else chain = 'bitcoin';
+      SuperClass = primitives.TX[chain];
+      assert(SuperClass, 'must use valid chain');
     }
 
-    this.DATE_FORMAT = null;
-    this._UXType = null;
-    this._labels = null;
-    this._json = null;
-    this._wallet = null;
-    this._account = null;
-    this._accounts = null;
-    this._counterparty = null;
-    this._recipients = null;
-    this._chain = null;
+    class TX extends SuperClass {
+        /**
+         * Create a UXTX
+         * User Experience Transaction
+         * @constructor
+         * @param options
+         *
+         * TODO: handle these cases:
+         * wallet/account -> same wallet/account
+         * wallet/account -> same wallet/different account
+         * coinjoin transactions
+         *
+         * TODO: overwrite TX.inspect
+         */
 
+        constructor(options) {
+          super();
+
+          // these are used as keys to look up
+          // in options.labels for toJSON labels
+          this.TYPES = {
+            COINBASE: 'COINBASE',
+            WITHDRAW: 'WITHDRAW',
+            DEPOSIT: 'DEPOSIT',
+            UNKNOWN: 'UNKNOWN',
+          }
+
+          this.DATE_FORMAT = null;
+          this._UXType = null;
+          this._labels = null;
+          this._json = null;
+          this._wallet = null;
+          this._account = null;
+          this._accounts = null;
+          this._counterparty = null;
+          this._recipients = null;
+          this._chain = null;
+
+          if (options)
+            this.fromOptions(options);
+        }
+
+        /**
+         * Inject properties from options object.
+         * @private
+         * @param {Object} options
+         * @param {Object} options.json - json encoded transaction
+         * @param {Object} options.json.wallet - wallet the tx belongs to
+         * @param {Object} options.constants - for calculating human readable info
+         * @param {Object} options.constants.DATE_FORMAT - moment.js date format string
+         * @param {Object} options.labels - human readable labels
+         * @param {String} options.wallet - wallet that the txs belong to
+         * @param {String} options.chain - chain transaction is valid on (bitcoin or bitcoincash)
+         */
+        fromOptions(options) {
+          super.fromOptions(options);
+          assert(options.json, 'tx object is required');
+          assert(typeof options.json === 'object', 'tx json must be an object');
+          this._json = options.json;
+
+          if (options.constants.DATE_FORMAT) {
+            assert(typeof options.constants.DATE_FORMAT === 'string');
+            this.DATE_FORMAT = options.constants.DATE_FORMAT;
+          }
+
+          if (options.labels) {
+            assert(typeof options.labels === 'object');
+            for (let [key, val] of Object.entries(options.labels))
+              assert(typeof val === 'string');
+            this._labels = options.labels;
+          }
+
+          if (options.wallet) {
+            assert(typeof options.wallet === 'string');
+            this._wallet = options.wallet;
+          }
+
+          // prioritize wallet information on individual
+          // transactions over global wallet information
+          if (options.json && options.json.wallet) {
+            assert(typeof options.json.wallet === 'string');
+            this._wallet = options.json.wallet;
+          }
+
+          if (options.chain) {
+            assert(typeof options.chain === 'string');
+            assert(
+              options.chain === 'bitcoin'
+                || options.chain === 'bitcoincash'
+                || options.chain === 'handshake',
+              'must pass a supported chain'
+            );
+            this._chain = options.chain;
+          }
+
+          return this;
+        }
+
+        /**
+         * Return user experience transaction
+         * types, these differentiate the
+         * labels to be displayed to a user
+         *
+         * @returns {Object}
+         */
+        getTypes() {
+          return this.TYPES;
+        }
+
+        /**
+         * Attempt to calculate if transaction is
+         * a withdrawal from a known account.
+         * Withdrawal defined by:
+         * more than 1 known input
+         * at least 1 known change output
+         *
+         * NOTE: not all withdrawals should actually have change
+         * but as of bcoin@1.0.2 they all do
+         *
+         * @returns {Boolean}
+         */
+        isWithdraw() {
+          const json = this.getJSON();
+
+          const knownOutputs = this.getKnownCoins('outputs');
+          const knownInputs = this.getKnownCoins('inputs');
+          const changeOutputs = this.getChangeCoins(knownOutputs);
+
+          if (knownInputs.length > 0 && changeOutputs.length > 0)
+            return true;
+
+          return false;
+        }
+
+        /*
+         * Attempt to calculate if transaction is
+         * a deposit.
+         * deposit defined by:
+         * no known inputs
+         * no change outputs
+         * @returns {Boolean}
+         */
+        isDeposit() {
+          const json = this.getJSON();
+          const knownInputs = this.getKnownCoins('inputs');
+          const changeOutputs = this.getChangeCoins(json.outputs);
+
+          if (knownInputs.length === 0 && changeOutputs.length === 0)
+            return true;
+
+          return false;
+        }
+
+        /*
+         * Get known coins
+         * known coin defined by:
+         * coin.path is not null
+         * type can be inputs, outputs
+         * undefined type gets both
+         * @param {String} type
+         * @returns {Boolean}
+         *
+         * TODO: cache and partially cache
+         * TODO: replace string input with enum
+         */
+        getKnownCoins(type) {
+          const json = this.getJSON();
+
+          if (type === 'inputs')
+            return json.inputs.filter(i => i.path);
+          if (type === 'outputs')
+            return json.outputs.filter(o => o.path);
+
+          // destructuring into new array
+          return [
+            ...json.inputs.filter(i => i.path),
+            ...json.outputs.filter(o => o.path),
+          ];
+        }
+
+        /*
+         * Get external coins
+         * external coin defined by:
+         * control by a private key
+         * external of the consumer's wallet
+         * @param {String} type
+         * @returns {Boolean}
+         *
+         * TODO: implement
+         * TODO: replace string input with enum
+         */
+        getExternalCoins(type) {
+          throw new Error('Not Implemented Error');
+        }
+
+        /*
+         * Get change coins
+         * change coin defined by:
+         * coin assigned to change address
+         * @param {Object[]} coins
+         * @param {Object} coins[].path
+         * @param {Boolean} coins[].path.change
+         * @returns {Object[]}
+         */
+        getChangeCoins(coins) {
+          return coins.filter(o => o.path && o.path.change);
+        }
+
+        /*
+         * Get value for inputs, outputs or both
+         * Convert from satoshis to unit
+         * see bcoin.Amount for accepted amounts
+         * @param {String} type
+         * @param {String} [unit='btc']
+         * @returns {Number}
+         */
+        getAmount(type, unit = 'btc') {
+          let coins;
+          const json = this.getJSON();
+
+          if (type === 'inputs')
+            coins = json.inputs;
+
+          else if (type === 'outputs')
+            coins = json.outputs;
+
+          else
+            coins = [...json.inputs, ...json.outputs];
+
+          const value = coins.reduce((a, o) => a + o.value, 0);
+          let amount = new Amount(value, 'sat');
+          return amount.to(unit);
+        }
+
+        /*
+         * Get value from known coins
+         * and return as string for pretty printing
+         * Convert from satoshis to unit
+         * see bcoin.Amount for accepted amounts
+         * @param {String} [unit='btc']
+         * @param {Boolean} [formatted=false] - add prefix '+'/'-'
+         * @returns {String}
+         */
+        getKnownAmount(unit = 'btc', formatted = false) {
+          let coins;
+          let prefix = '';
+          switch(this.getUXType()) {
+            case this.TYPES.DEPOSIT:
+              coins = this.getKnownCoins('outputs')
+              prefix = '+';
+              break;
+            case this.TYPES.WITHDRAW:
+              coins = this.getKnownCoins('inputs');
+              prefix = '-';
+              break;
+            case this.TYPES.COINBASE:
+              coins = this.getJSON().outputs;
+              prefix = '+';
+              break;
+            case this.TYPES.UNKNOWN:
+            default:
+              // something went wrong...
+              coins = [];
+          }
+
+          const value = coins.reduce((a, c) => a + c.value, 0);
+          let amount = new Amount(value, 'sat');
+          amount = amount.to(unit);
+
+          if (formatted)
+            return `${prefix}${amount}`;
+
+          return `${amount}`;
+        }
+
+        /*
+         * Get bcoin.TX json
+         * @returns {Object}
+         *
+         * TODO: rename this.getJSON to
+         * this.getTXJSON
+         */
+        getJSON() {
+          assert(this._json);
+          return this._json;
+        }
+
+        /*
+         * Get wallet name
+         * @returns {String}
+         */
+        getWallet() {
+          return this._wallet;
+        }
+
+        /*
+         * Get chain type - bitcoin,bitcoincash
+         * @returns {String}
+         */
+        getChain() {
+          return this._chain;
+        }
+
+        /*
+         * Get account names
+         * @returns {[]String}
+         */
+        getAccounts() {
+          if (this._accounts)
+            return this._accounts;
+
+          let accounts;
+
+          const labels = this.getLabels();
+          const json = this.getJSON();
+
+          switch(this.getUXType()) {
+            case this.TYPES.DEPOSIT: // receive transaction
+
+              accounts = this.getKnownCoins('inputs')
+                .filter(i => !i.path.change) // filter out change utxo
+                .map(i => i.path.name)
+
+              break;
+            case this.TYPES.WITHDRAW: // send transaction
+              accounts = json.outputs
+                .filter(o => {
+                  // only will have path property
+                  // if controlled by wallet
+                  if (o.path)
+                    return !o.path.change;
+                    // handle sending to controlled wallet
+                  return true; // all remaining outputs included
+                })
+                .map(o => {
+                  if (o.path)  // known outputs will have an account name
+                    return o.path.name;
+                  return null;
+                });
+
+              break;
+            case this.TYPES.COINBASE:
+              // null account when not controlled wallet
+              if (json.outputs[0].path)
+                accounts = [json.outputs[0].path.name];
+              else
+                accounts = [null];
+
+              break;
+            case this.TYPES.UNKNOWN:
+            default:
+              accounts = []
+          }
+
+          this._accounts = accounts;
+          return accounts;
+        }
+
+
+        /*
+         * Get displayed account name
+         * @returns {String}
+         */
+        getAccount() {
+          if (this._account)
+            return this._account;
+
+          let account;
+          let knownOutputs = this.getKnownCoins('outputs');
+          const knownInputs = this.getKnownCoins('inputs');
+          const json = this.getJSON();
+          const labels = this.getLabels();
+
+          switch(this.getUXType()) {
+            case this.TYPES.DEPOSIT:
+              // account that received coin
+
+              if (knownOutputs.length > 1)
+                account = labels.MULTIPLE_ACCOUNT;
+              else if (knownOutputs.length === 1)
+                account = knownOutputs[0].path.name;
+              else
+                account = labels.UNKNOWN_ACCOUNT;
+
+              break;
+            case this.TYPES.WITHDRAW:
+              // account sending coin
+
+              if (knownInputs.length > 1)
+                account = labels.MULTIPLE_ACCOUNT;
+              else if (knownInputs.length === 1)
+                account = knownInputs[0].path.name;
+              else
+                account = labels.UNKNOWN_ACCOUNT;
+
+              break;
+            case this.TYPES.COINBASE:
+              // account that received coin
+
+              // look before you leap
+              if (json.outputs.length === 1 && json.outputs[0].path)
+                account = json.outputs[0].path.name;
+              else
+                account = labels.UNKNOWN_ACCOUNT;
+
+              break;
+            case this.TYPES.UNKNOWN:
+            default:
+              account = labels.UNKNOWN_ACCOUNT;
+
+              break;
+          }
+
+          this._account = account;
+          return account
+        }
+
+        /*
+         * Get tx user experience type
+         * Determines which human readable labels
+         * are parsed
+         * @returns {String}
+         */
+        getUXType() {
+          if (this._UXType)
+            return this._UXType;
+
+          let UXType;
+          if (this.isCoinbase())
+            UXType = this.TYPES.COINBASE;
+
+          else if (this.isDeposit())
+            UXType = this.TYPES.DEPOSIT;
+
+          else if (this.isWithdraw())
+            UXType = this.TYPES.WITHDRAW;
+
+          else
+            UXType = this.TYPES.UNKNOWN;
+
+          this._UXType = UXType;
+          return UXType;
+
+        }
+
+        /*
+         * Get tx counterparty
+         * @returns {String}
+         *
+         * TODO: move accounts parsing out of this
+         * and into this.getAccounts
+         *
+         * TODO: move recipients parsing out of this
+         * and into this.getRecipients
+         */
+        getCounterparty() {
+          let counterparty;
+          let accounts;
+
+          const labels = this.getLabels();
+          const json = this.getJSON();
+
+          switch(this.getUXType()) {
+            case this.TYPES.DEPOSIT: // receive transaction
+              // parse counterparty
+              if (json.inputs.length > 1)
+                counterparty = labels.MULTIPLE_ADDRESS;
+              else if (json.inputs.length === 1)
+                counterparty = json.inputs[0].address;
+                // TODO: this can be a null value
+              else
+                counterparty = labels.UNKNOWN_ADDRESS;
+
+              break;
+            case this.TYPES.WITHDRAW: // send transaction
+              // TODO: remove concept of recipients
+              const outputs= json.outputs
+                .filter(o => {
+                  // only will have path property
+                  // if controlled by wallet
+                  if (o.path)
+                    return !o.path.change;
+                    // handle sending to controlled wallet
+
+                  return true; // all remaining outputs included
+                });
+              const recipients = outputs.map(o => o.address);
+
+              // parse counterpary based on number of recipients
+              if (recipients.length === 1)
+                counterparty = recipients[0];
+              else if (recipients.length > 1)
+                counterparty = labels.MULTIPLE_ADDRESS;
+              else
+                counterparty = labels.UNKNOWN_ADDRESS;
+
+              break;
+            case this.TYPES.COINBASE:
+              // assume one input and one output
+              counterparty = json.outputs[0].address;
+
+              break;
+            case this.TYPES.UNKNOWN:
+            default:
+              counterparty = labels.UNKNOWN_ADDRESS;
+          }
+
+          this._counterparty = counterparty;
+          return counterparty;
+        }
+
+        /*
+         * Get tx recipients
+         * @returns {String}
+         */
+        getRecipients() {
+          if (this._recipients)
+            return this._recipients;
+
+          let recipients;
+
+          const labels = this.getLabels();
+          const json = this.getJSON();
+
+          switch(this.getUXType()) {
+            case this.TYPES.DEPOSIT: // receive transaction
+              // parse recipients
+              // TODO: catch edge cases here around more complex txns
+              recipients = json.inputs.map(i => i.address)
+
+              break;
+            case this.TYPES.WITHDRAW: // send transaction
+              // parse recipients
+              const outputs= json.outputs
+                .filter(o => {
+                  // only will have path property
+                  // if controlled by wallet
+                  if (o.path)
+                    return !o.path.change;
+                    // handle sending to controlled wallet
+
+                  return true; // all remaining outputs included
+                })
+                .map(o => o.address);
+
+              break;
+            case this.TYPES.COINBASE:
+              // assume one input and one output
+              recipients = [json.outputs[0].address];
+
+              break;
+            case this.TYPES.UNKNOWN:
+            default:
+              recipients = [];
+          }
+
+          this._recipients = recipients;
+          return recipients;
+        }
+
+        /*
+         * Get human readable labels
+         * These can be configured with this.fromOptions
+         * @param {String} label - return a specific labels value
+         * @returns {Object|String}
+         */
+        getLabels(label) {
+          if (label)
+            return this._labels[label];
+          return this._labels;
+        }
+
+        /*
+         * Get human readable labels
+         * These can be configured with this.fromOptions
+         * @static
+         * @param {String|Buffer} data - raw tx data
+         * @param {String} enc - encoding raw tx data is in
+         * @param {Objects} options - UXTX options
+         * @returns {Object|String}
+         */
+        static fromRaw(data, enc, options) {
+          if (typeof data === 'string')
+            data = Buffer.from(data, enc);
+          return new this(options).fromRaw(data);
+        }
+
+        /*
+         * Get JSON with human readable values in it
+         * @returns {Object}
+         *
+         * TODO: consolidate output values to make most flexible
+         * TODO: don't hardcode segwit and coinbase labels
+         */
+        toJSON() {
+          const json = this.getJSON();
+          const date = moment(json.date)
+            .format(this.DATE_FORMAT);
+
+          const uxtype = this.getUXType();
+          const counterparty = this.getCounterparty();
+          const recipients = this.getRecipients();
+          const accounts = this.getAccounts();
+
+          const wallet = this.getWallet();
+          const amount = this.getKnownAmount('btc', true);
+          const chain = this.getChain();
+
+          const account = this.getAccount();
+          const uxtypeLabel = this.getLabels(uxtype);
+
+          const isSegwit = this.hasWitness();
+          const isCoinbase = this.isCoinbase();
+          const weight = this.getWeight();
+
+          const inputAmount = this.getAmount('inputs');
+          const outputAmount = this.getAmount('outputs');
+
+
+          return {
+            hash: json.hash,
+            fee: json.fee,
+            rate: json.rate,
+            size: json.size,
+            block: json.block, // block hash
+            isSegwit,
+            isCoinbase,
+            tx: json.tx,
+            height: json.height,
+            inputs: json.inputs,
+            outputs: json.outputs,
+            inputAmount,
+            outputAmount,
+            inputCount: json.inputs.length,
+            outputCount: json.outputs.length,
+            weight,
+            mdate: json.mdate,
+            date,
+            amount,
+            wallet,  // must be provided by fn consumer
+            accounts,
+            confirmations: json.confirmations,
+            recipients,
+            addressLabel: counterparty,
+            accountLabel: account,
+            segwitLabel: isSegwit ? 'Yes' : 'No',
+            coinbaseLabel: isCoinbase ? 'Yes' : 'No',
+            chain,
+            uxtype: uxtypeLabel,
+          };
+        }
+      }
+
+    this._txClass = TX;
     if (options)
       this.fromOptions(options);
   }
 
-  /**
-   * Inject properties from options object.
-   * @private
-   * @param {Object} options
-   * @param {Object} options.json - json encoded transaction
-   * @param {Object} options.json.wallet - wallet the tx belongs to
-   * @param {Object} options.constants - for calculating human readable info
-   * @param {Object} options.constants.DATE_FORMAT - moment.js date format string
-   * @param {Object} options.labels - human readable labels
-   * @param {String} options.wallet - wallet that the txs belong to
-   * @param {String} options.chain - chain transaction is valid on (bitcoin or bitcoincash)
-   */
-  fromOptions(options) {
-    // allow for bcoin.TX options
-    super.fromOptions(options);
-    assert(options.json, 'tx object is required');
-    assert(typeof options.json === 'object', 'tx json must be an object');
-    this._json = options.json;
-
-    if (options.constants.DATE_FORMAT) {
-      assert(typeof options.constants.DATE_FORMAT === 'string');
-      this.DATE_FORMAT = options.constants.DATE_FORMAT;
-    }
-
-    if (options.labels) {
-      assert(typeof options.labels === 'object');
-      for (let [key, val] of Object.entries(options.labels))
-        assert(typeof val === 'string');
-      this._labels = options.labels;
-    }
-
-    if (options.wallet) {
-      assert(typeof options.wallet === 'string');
-      this._wallet = options.wallet;
-    }
-
-    // prioritize wallet information on individual
-    // transactions over global wallet information
-    if (options.json && options.json.wallet) {
-      assert(typeof options.json.wallet === 'string');
-      this._wallet = options.json.wallet;
-    }
-
-    if (options.chain) {
-      assert(typeof options.chain === 'string');
-      // TODO: handshake support
-      assert(options.chain === 'bitcoin' || options.chain === 'bitcoincash', 'must pass a supported chain');
-      this._chain = options.chain;
-    }
-
-    return this;
+  static fromOptions(options, SuperClass) {
+    return new this(null, SuperClass).fromOptions(options);
   }
 
-  /**
-   * Return user experience transaction
-   * types, these differentiate the
-   * labels to be displayed to a user
-   *
-   * @returns {Object}
-   */
-  getTypes() {
-    return this.TYPES;
+  // allow for dynamic subclassing
+  fromOptions(options, SuperClass) {
+    return new this._txClass(options).fromOptions(options);
   }
 
-  /**
-   * Attempt to calculate if transaction is
-   * a withdrawal from a known account.
-   * Withdrawal defined by:
-   * more than 1 known input
-   * at least 1 known change output
-   *
-   * NOTE: not all withdrawals should actually have change
-   * but as of bcoin@1.0.2 they all do
-   *
-   * @returns {Boolean}
-   */
-  isWithdraw() {
-    const json = this.getJSON();
-
-    const knownOutputs = this.getKnownCoins('outputs');
-    const knownInputs = this.getKnownCoins('inputs');
-    const changeOutputs = this.getChangeCoins(knownOutputs);
-
-    if (knownInputs.length > 0 && changeOutputs.length > 0)
-      return true;
-
-    return false;
-  }
-
-  /*
-   * Attempt to calculate if transaction is
-   * a deposit.
-   * deposit defined by:
-   * no known inputs
-   * no change outputs
-   * @returns {Boolean}
-   */
-  isDeposit() {
-    const json = this.getJSON();
-    const knownInputs = this.getKnownCoins('inputs');
-    const changeOutputs = this.getChangeCoins(json.outputs);
-
-    if (knownInputs.length === 0 && changeOutputs.length === 0)
-      return true;
-
-    return false;
-  }
-
-  /*
-   * Get known coins
-   * known coin defined by:
-   * coin.path is not null
-   * type can be inputs, outputs
-   * undefined type gets both
-   * @param {String} type
-   * @returns {Boolean}
-   *
-   * TODO: cache and partially cache
-   * TODO: replace string input with enum
-   */
-  getKnownCoins(type) {
-    const json = this.getJSON();
-
-    if (type === 'inputs')
-      return json.inputs.filter(i => i.path);
-    if (type === 'outputs')
-      return json.outputs.filter(o => o.path);
-
-    // destructuring into new array
-    return [
-      ...json.inputs.filter(i => i.path),
-      ...json.outputs.filter(o => o.path),
-    ];
-  }
-
-  /*
-   * Get external coins
-   * external coin defined by:
-   * control by a private key
-   * external of the consumer's wallet
-   * @param {String} type
-   * @returns {Boolean}
-   *
-   * TODO: implement
-   * TODO: replace string input with enum
-   */
-  getExternalCoins(type) {
-    throw new Error('Not Implemented Error');
-  }
-
-  /*
-   * Get change coins
-   * change coin defined by:
-   * coin assigned to change address
-   * @param {Object[]} coins
-   * @param {Object} coins[].path
-   * @param {Boolean} coins[].path.change
-   * @returns {Object[]}
-   */
-  getChangeCoins(coins) {
-    return coins.filter(o => o.path && o.path.change);
-  }
-
-  /*
-   * Get value for inputs, outputs or both
-   * Convert from satoshis to unit
-   * see bcoin.Amount for accepted amounts
-   * @param {String} type
-   * @param {String} [unit='btc']
-   * @returns {Number}
-   */
-  getAmount(type, unit = 'btc') {
-    let coins;
-    const json = this.getJSON();
-
-    if (type === 'inputs')
-      coins = json.inputs;
-
-    else if (type === 'outputs')
-      coins = json.outputs;
-
-    else
-      coins = [...json.inputs, ...json.outputs];
-
-    const value = coins.reduce((a, o) => a + o.value, 0);
-    let amount = new Amount(value, 'sat');
-    return amount.to(unit);
-  }
-
-  /*
-   * Get value from known coins
-   * and return as string for pretty printing
-   * Convert from satoshis to unit
-   * see bcoin.Amount for accepted amounts
-   * @param {String} [unit='btc']
-   * @param {Boolean} [formatted=false] - add prefix '+'/'-'
-   * @returns {String}
-   */
-  getKnownAmount(unit = 'btc', formatted = false) {
-    let coins;
-    let prefix = '';
-    switch(this.getUXType()) {
-      case this.TYPES.DEPOSIT:
-        coins = this.getKnownCoins('outputs')
-        prefix = '+';
-        break;
-      case this.TYPES.WITHDRAW:
-        coins = this.getKnownCoins('inputs');
-        prefix = '-';
-        break;
-      case this.TYPES.COINBASE:
-        coins = this.getJSON().outputs;
-        prefix = '+';
-        break;
-      case this.TYPES.UNKNOWN:
-      default:
-        // something went wrong...
-        coins = [];
-    }
-
-    const value = coins.reduce((a, c) => a + c.value, 0);
-    let amount = new Amount(value, 'sat');
-    amount = amount.to(unit);
-
-    if (formatted)
-      return `${prefix}${amount}`;
-
-    return `${amount}`;
-  }
-
-  /*
-   * Get bcoin.TX json
-   * @returns {Object}
-   *
-   * TODO: rename this.getJSON to
-   * this.getTXJSON
-   */
-  getJSON() {
-    assert(this._json);
-    return this._json;
-  }
-
-  /*
-   * Get wallet name
-   * @returns {String}
-   */
-  getWallet() {
-    return this._wallet;
-  }
-
-  /*
-   * Get chain type - bitcoin,bitcoincash
-   * @returns {String}
-   */
-  getChain() {
-    return this._chain;
-  }
-
-  /*
-   * Get account names
-   * @returns {[]String}
-   */
-  getAccounts() {
-    if (this._accounts)
-      return this._accounts;
-
-    let accounts;
-
-    const labels = this.getLabels();
-    const json = this.getJSON();
-
-    switch(this.getUXType()) {
-      case this.TYPES.DEPOSIT: // receive transaction
-
-        accounts = this.getKnownCoins('inputs')
-          .filter(i => !i.path.change) // filter out change utxo
-          .map(i => i.path.name)
-
-        break;
-      case this.TYPES.WITHDRAW: // send transaction
-        accounts = json.outputs
-          .filter(o => {
-            // only will have path property
-            // if controlled by wallet
-            if (o.path)
-              return !o.path.change;
-              // handle sending to controlled wallet
-            return true; // all remaining outputs included
-          })
-          .map(o => {
-            if (o.path)  // known outputs will have an account name
-              return o.path.name;
-            return null;
-          });
-
-        break;
-      case this.TYPES.COINBASE:
-        // null account when not controlled wallet
-        if (json.outputs[0].path)
-          accounts = [json.outputs[0].path.name];
-        else
-          accounts = [null];
-
-        break;
-      case this.TYPES.UNKNOWN:
-      default:
-        accounts = []
-    }
-
-    this._accounts = accounts;
-    return accounts;
-  }
-
-
-  /*
-   * Get displayed account name
-   * @returns {String}
-   */
-  getAccount() {
-    if (this._account)
-      return this._account;
-
-    let account;
-    let knownOutputs = this.getKnownCoins('outputs');
-    const knownInputs = this.getKnownCoins('inputs');
-    const json = this.getJSON();
-    const labels = this.getLabels();
-
-    switch(this.getUXType()) {
-      case this.TYPES.DEPOSIT:
-        // account that received coin
-
-        if (knownOutputs.length > 1)
-          account = labels.MULTIPLE_ACCOUNT;
-        else if (knownOutputs.length === 1)
-          account = knownOutputs[0].path.name;
-        else
-          account = labels.UNKNOWN_ACCOUNT;
-
-        break;
-      case this.TYPES.WITHDRAW:
-        // account sending coin
-
-        if (knownInputs.length > 1)
-          account = labels.MULTIPLE_ACCOUNT;
-        else if (knownInputs.length === 1)
-          account = knownInputs[0].path.name;
-        else
-          account = labels.UNKNOWN_ACCOUNT;
-
-        break;
-      case this.TYPES.COINBASE:
-        // account that received coin
-
-        // look before you leap
-        if (json.outputs.length === 1 && json.outputs[0].path)
-          account = json.outputs[0].path.name;
-        else
-          account = labels.UNKNOWN_ACCOUNT;
-
-        break;
-      case this.TYPES.UNKNOWN:
-      default:
-        account = labels.UNKNOWN_ACCOUNT;
-
-        break;
-    }
-
-    this._account = account;
-    return account
-  }
-
-  /*
-   * Get tx user experience type
-   * Determines which human readable labels
-   * are parsed
-   * @returns {String}
-   */
-  getUXType() {
-    if (this._UXType)
-      return this._UXType;
-
-    let UXType;
-    if (this.isCoinbase())
-      UXType = this.TYPES.COINBASE;
-
-    else if (this.isDeposit())
-      UXType = this.TYPES.DEPOSIT;
-
-    else if (this.isWithdraw())
-      UXType = this.TYPES.WITHDRAW;
-
-    else
-      UXType = this.TYPES.UNKNOWN;
-
-    this._UXType = UXType;
-    return UXType;
-
-  }
-
-  /*
-   * Get tx counterparty
-   * @returns {String}
-   *
-   * TODO: move accounts parsing out of this
-   * and into this.getAccounts
-   *
-   * TODO: move recipients parsing out of this
-   * and into this.getRecipients
-   */
-  getCounterparty() {
-    let counterparty;
-    let accounts;
-
-    const labels = this.getLabels();
-    const json = this.getJSON();
-
-    switch(this.getUXType()) {
-      case this.TYPES.DEPOSIT: // receive transaction
-        // parse counterparty
-        if (json.inputs.length > 1)
-          counterparty = labels.MULTIPLE_ADDRESS;
-        else if (json.inputs.length === 1)
-          counterparty = json.inputs[0].address;
-          // TODO: this can be a null value
-        else
-          counterparty = labels.UNKNOWN_ADDRESS;
-
-        break;
-      case this.TYPES.WITHDRAW: // send transaction
-        // TODO: remove concept of recipients
-        const outputs= json.outputs
-          .filter(o => {
-            // only will have path property
-            // if controlled by wallet
-            if (o.path)
-              return !o.path.change;
-              // handle sending to controlled wallet
-
-            return true; // all remaining outputs included
-          });
-        const recipients = outputs.map(o => o.address);
-
-        // parse counterpary based on number of recipients
-        if (recipients.length === 1)
-          counterparty = recipients[0];
-        else if (recipients.length > 1)
-          counterparty = labels.MULTIPLE_ADDRESS;
-        else
-          counterparty = labels.UNKNOWN_ADDRESS;
-
-        break;
-      case this.TYPES.COINBASE:
-        // assume one input and one output
-        counterparty = json.outputs[0].address;
-
-        break;
-      case this.TYPES.UNKNOWN:
-      default:
-        counterparty = labels.UNKNOWN_ADDRESS;
-    }
-
-    this._counterparty = counterparty;
-    return counterparty;
-  }
-
-  /*
-   * Get tx recipients
-   * @returns {String}
-   */
-  getRecipients() {
-    if (this._recipients)
-      return this._recipients;
-
-    let recipients;
-
-    const labels = this.getLabels();
-    const json = this.getJSON();
-
-    switch(this.getUXType()) {
-      case this.TYPES.DEPOSIT: // receive transaction
-        // parse recipients
-        // TODO: catch edge cases here around more complex txns
-        recipients = json.inputs.map(i => i.address)
-
-        break;
-      case this.TYPES.WITHDRAW: // send transaction
-        // parse recipients
-        const outputs= json.outputs
-          .filter(o => {
-            // only will have path property
-            // if controlled by wallet
-            if (o.path)
-              return !o.path.change;
-              // handle sending to controlled wallet
-
-            return true; // all remaining outputs included
-          })
-          .map(o => o.address);
-
-        break;
-      case this.TYPES.COINBASE:
-        // assume one input and one output
-        recipients = [json.outputs[0].address];
-
-        break;
-      case this.TYPES.UNKNOWN:
-      default:
-        recipients = [];
-    }
-
-    this._recipients = recipients;
-    return recipients;
-  }
-
-  /*
-   * Get human readable labels
-   * These can be configured with this.fromOptions
-   * @param {String} label - return a specific labels value
-   * @returns {Object|String}
-   */
-  getLabels(label) {
-    if (label)
-      return this._labels[label];
-    return this._labels;
-  }
-
-  /*
-   * Get human readable labels
-   * These can be configured with this.fromOptions
-   * @static
-   * @param {String|Buffer} data - raw tx data
-   * @param {String} enc - encoding raw tx data is in
-   * @param {Objects} options - UXTX options
-   * @returns {Object|String}
-   */
   static fromRaw(data, enc, options) {
     if (typeof data === 'string')
       data = Buffer.from(data, enc);
-    return new this(options).fromRaw(data);
+    return new this().fromRaw(data, enc, options);
   }
 
-  /*
-   * Get JSON with human readable values in it
-   * @returns {Object}
-   *
-   * TODO: consolidate output values to make most flexible
-   * TODO: don't hardcode segwit and coinbase labels
-   */
-  toJSON() {
-    const json = this.getJSON();
-    const date = moment(json.date)
-      .format(this.DATE_FORMAT);
-
-    const uxtype = this.getUXType();
-    const counterparty = this.getCounterparty();
-    const recipients = this.getRecipients();
-    const accounts = this.getAccounts();
-
-    const wallet = this.getWallet();
-    const amount = this.getKnownAmount('btc', true);
-    const chain = this.getChain();
-
-    const account = this.getAccount();
-    const uxtypeLabel = this.getLabels(uxtype);
-
-    const isSegwit = this.hasWitness();
-    const isCoinbase = this.isCoinbase();
-    const weight = this.getWeight();
-
-    const inputAmount = this.getAmount('inputs');
-    const outputAmount = this.getAmount('outputs');
-
-
-    return {
-      hash: json.hash,
-      fee: json.fee,
-      rate: json.rate,
-      size: json.size,
-      block: json.block, // block hash
-      isSegwit,
-      isCoinbase,
-      tx: json.tx,
-      height: json.height,
-      inputs: json.inputs,
-      outputs: json.outputs,
-      inputAmount,
-      outputAmount,
-      inputCount: json.inputs.length,
-      outputCount: json.outputs.length,
-      weight,
-      mdate: json.mdate,
-      date,
-      amount,
-      wallet,  // must be provided by fn consumer
-      accounts,
-      confirmations: json.confirmations,
-      recipients,
-      addressLabel: counterparty,
-      accountLabel: account,
-      segwitLabel: isSegwit ? 'Yes' : 'No',
-      coinbaseLabel: isCoinbase ? 'Yes' : 'No',
-      chain,
-      uxtype: uxtypeLabel,
-    };
+  fromRaw(data, enc, options) {
+    if (typeof data === 'string')
+      data = Buffer.from(data, enc);
+    return this._txClass.fromRaw(data, enc, options);
   }
 }
+
 
 // initial label values
 // NOTE: many are the same, but
@@ -679,7 +730,7 @@ const constants = {
 };
 
 // valid networks:
-// bitcoin, bitcoincash
+// bitcoin, bitcoincash, handshake
 const chain = null;
 
 // additional options for UXTX
@@ -690,7 +741,7 @@ const UXTXOptions = {
   json: null, // tx json
 };
 
-module.exports = {
+export {
   UXTX,
   UXTXOptions,
 }

--- a/lib/uxtx.js
+++ b/lib/uxtx.js
@@ -699,7 +699,7 @@ class UXTX {
   static fromRaw(data, enc, options) {
     if (typeof data === 'string')
       data = Buffer.from(data, enc);
-    return new this().fromRaw(data, enc, options);
+    return new this(options).fromRaw(data, enc, options);
   }
 
   fromRaw(data, enc, options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1925,9 +1925,9 @@
           }
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w==",
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g==",
           "dev": true
         },
         "bsip": {
@@ -5396,9 +5396,9 @@
           }
         },
         "bsert": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.5.tgz",
-          "integrity": "sha512-prgSa82RHcsdEM7SKYl1S7j0tKeiE3SF8C3B39MyUrpbP66diJK16RIkbFC2pXvQx4xitN0xMgBHKBAgBldX1w==",
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.7.tgz",
+          "integrity": "sha512-m/DKdJbnoviiE6f+I2/Kl0ESQoVSfYv1xYczVItrPyzRrMS0VXebRzzcAJ0ZusyBJbofND8X9RGHzvQoMpnf+g==",
           "dev": true
         },
         "bsip": {


### PR DESCRIPTION
Adds helpers for plugins that want to work between blockchains
The data will not be parsed properly for `bcoin.TX` vs `hsd.TX` so this imports and wraps primitives such that you can pass along the data and get the proper primitive that
you need. This is very helpful for dynamic switching between chains

The new currency utility should be added to this as well, but the multisig stuff is more important